### PR TITLE
xpmem stuff

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -174,6 +174,7 @@ dnl
 dnl Arguments:
 dnl
 dnl $1: directory to check
+dnl $2: prefix to set output values $2_PREFIX and $2_LIBDIR
 dnl
 AC_DEFUN([FI_CHECK_PREFIX_DIR],[
 	# Check that the base directory exists

--- a/configure.ac
+++ b/configure.ac
@@ -249,7 +249,10 @@ AC_ARG_ENABLE([xpmem],
 			       (yes: enabled xpmem; no: disable xpmem;
 				PATH: enable xpmem and use xpmem installed under PATH)])],
               )
-
+AS_CASE([$enable_xpmem],
+	[yes|no], [],
+	[FI_CHECK_PREFIX_DIR([$enable_xpmem], [xpmem])]
+	)
 
 dnl Disable symbol versioning when -ipo is in CFLAGS or ipo is disabled by icc.
 dnl The gcc equivalent ipo (-fwhole-program) seems to work fine.

--- a/prov/shm/Makefile.include
+++ b/prov/shm/Makefile.include
@@ -16,13 +16,18 @@ _shm_files = \
 
 if HAVE_SHM_DL
 pkglib_LTLIBRARIES += libshm-fi.la
+libshm_fi_la_CPPFLAGS = 		\
+	-I$(top_srcdir)/include		\
+	$(AM_CPPFLAGS) $(xpmem_CPPFLAGS)
 libshm_fi_la_SOURCES = $(_shm_files) $(common_srcs)
-libshm_fi_la_LIBADD = $(linkback) $(shm_lib_LIBS)
-libshm_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libshm_fi_la_LIBADD = $(linkback) $(shm_lib_LIBS) $(xpmem_LIBS)
+libshm_fi_la_LDFLAGS = $(xpmem_LDFLAGS) -module -avoid-version -shared -export-dynamic
 libshm_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_SHM_DL
+src_libfabric_la_CPPFLAGS += $(xpmem_CPPFLAGS)
 src_libfabric_la_SOURCES += $(_shm_files)
-src_libfabric_la_LIBADD += $(shm_lib_LIBS)
+src_libfabric_la_LIBADD += $(shm_lib_LIBS) $(xpmem_LIBS)
+src_libfabric_la_LDFLAGS += $(xpmem_LDFLAGS)
 endif !HAVE_SHM_DL
 
 prov_install_man_pages += man/man7/fi_shm.7

--- a/prov/shm/configure.m4
+++ b/prov/shm/configure.m4
@@ -30,8 +30,10 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 			     [shm_happy=0])
 
                AS_IF([test "$enable_xpmem" = "no"],
-		     [xpmem_happy=0],
-		     [xpmem_happy=1])
+		     [want_xpmem=0
+		      xpmem_happy=0],
+		     [want_xpmem=1
+		      xpmem_happy=1])
 
 	       AS_IF([test $xpmem_happy -eq 1 -a "$enable_xpmem" != "yes"],
 		      [CPPFLAGS="$CPPFLAGS -I$enable_xpmem/include"
@@ -54,6 +56,11 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 		     [AC_DEFINE([XPMEM_ACTIVE], [1],
 				[Define if XPMEM support is available])],
 		     [])
+
+	       # if xpmem was requested but we can't deliver it, abort
+	       AS_IF([test $want_xpmem -eq 1 && test $xpmem_happy -eq 0],
+		     [AC_MSG_WARN([xpmem support requested, but is unavailable])
+		      AC_MSG_ERROR([Cannot continue])])
 
 	       # look for shm_open in librt if not already present
 	       AS_IF([test $shm_happy -eq 0],

--- a/prov/shm/configure.m4
+++ b/prov/shm/configure.m4
@@ -35,11 +35,6 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 		     [want_xpmem=1
 		      xpmem_happy=1])
 
-	       AS_IF([test $xpmem_happy -eq 1 -a "$enable_xpmem" != "yes"],
-		      [CPPFLAGS="$CPPFLAGS -I$enable_xpmem/include"
-		       LDFLAGS="$LDFLAGS -L$enable_xpmem/lib"],
-		      [])
-
 	       # check if XPMEM support is present
 	       AS_IF([test $xpmem_happy -eq 1],
 		     [FI_CHECK_PACKAGE([xpmem],
@@ -47,8 +42,8 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 	 			[xpmem],
 				[xpmem_make],
 				[],
-				[],
-				[],
+				[$xpmem_PREFIX],
+				[$xpmem_LIBDIR],
 				[],
 				[xpmem_happy=0])])
 
@@ -61,6 +56,10 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 	       AS_IF([test $want_xpmem -eq 1 && test $xpmem_happy -eq 0],
 		     [AC_MSG_WARN([xpmem support requested, but is unavailable])
 		      AC_MSG_ERROR([Cannot continue])])
+
+	       AC_SUBST(xpmem_CPPFLAGS)
+	       AC_SUBST(xpmem_LDFLAGS)
+	       AC_SUBST(xpmem_LIBS)
 
 	       # look for shm_open in librt if not already present
 	       AS_IF([test $shm_happy -eq 0],


### PR DESCRIPTION
You were pretty close, but it probably would have been pretty hard to find the use of `FI_CHECK_PREFIX_DIR`.

Also, the other two key points were:

1. Do not set CPPFLAGS (and friends) directly, but rather pass in the prefix/libdir to FI_CHECK_PACKAGE, and let it figure out the xpmem-specific CPPFLAGS (and friends).
1. Use the xpmem-specific CPPFLAGS (and friends) in `prov/shm/Makefile.include`

I also included some extra crispy bonus commits (which should also go upstream, even though they weren't technically part of fixing the xpmem stuff).  Check out the commit messages of each of the commits.

Enjoy.