### PR TITLE
prov/sm2: Add util srx support to SM2

### DIFF
--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -154,16 +154,22 @@ int sm2_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 int sm2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		struct fid_av **av, void *context);
 
-static inline int sm2_match_id(fi_addr_t addr, fi_addr_t match_addr)
+static inline enum fi_hmem_iface
+sm2_get_mr_hmem_iface(struct util_domain *domain, void **desc, uint64_t *device)
 {
-	return (addr == FI_ADDR_UNSPEC) || (match_addr == FI_ADDR_UNSPEC) ||
-	       (addr == match_addr);
+	if (!(domain->mr_mode & FI_MR_HMEM) || !desc || !*desc) {
+		*device = 0;
+		return FI_HMEM_SYSTEM;
+	}
+
+	*device = ((struct ofi_mr *) *desc)->device;
+	return ((struct ofi_mr *) *desc)->iface;
 }
 
-static inline int sm2_match_tag(uint64_t tag, uint64_t ignore,
-				uint64_t match_tag)
+static inline uint64_t sm2_get_mr_flags(void **desc)
 {
-	return ((tag | ignore) == (match_tag | ignore));
+	assert(desc && *desc);
+	return ((struct ofi_mr *) *desc)->flags;
 }
 
 struct sm2_xfer_ctx {
@@ -177,49 +183,6 @@ struct sm2_domain {
 	struct fid_peer_srx *srx;
 };
 
-struct sm2_rx_entry {
-	struct fi_peer_rx_entry peer_entry;
-	struct iovec iov[SM2_IOV_LIMIT];
-	void *desc[SM2_IOV_LIMIT];
-	int64_t peer_id;
-	uint64_t ignore;
-	int multi_recv_ref;
-	uint64_t err;
-};
-
-struct sm2_queue {
-	struct dlist_entry list;
-	dlist_func_t *match_func;
-};
-
-OFI_DECLARE_FREESTACK(struct sm2_rx_entry, sm2_recv_fs);
-
-struct sm2_match_attr {
-	fi_addr_t id;
-	uint64_t tag;
-	uint64_t ignore;
-};
-
-struct sm2_srx_ctx {
-	struct fid_peer_srx peer_srx;
-	struct sm2_queue recv_queue;
-	struct sm2_queue trecv_queue;
-	bool dir_recv;
-	size_t min_multi_recv_size;
-	uint64_t rx_op_flags;
-	uint64_t rx_msg_flags;
-
-	struct util_cq *cq;
-	struct sm2_queue unexp_msg_queue;
-	struct sm2_queue unexp_tagged_queue;
-	struct sm2_recv_fs *recv_fs;
-
-	// TODO Determine if this spin lock is needed.
-	ofi_spin_t lock;
-};
-
-struct sm2_rx_entry *sm2_alloc_rx_entry(struct sm2_srx_ctx *srx);
-
 struct sm2_ep {
 	struct util_ep util_ep;
 	size_t rx_size;
@@ -231,11 +194,6 @@ struct sm2_ep {
 	struct ofi_bufpool *xfer_ctx_pool;
 	int ep_idx;
 };
-
-static inline struct sm2_srx_ctx *sm2_get_srx(struct sm2_ep *ep)
-{
-	return (struct sm2_srx_ctx *) ep->srx->fid.context;
-}
 
 static inline struct fid_peer_srx *sm2_get_peer_srx(struct sm2_ep *ep)
 {
@@ -301,16 +259,5 @@ static inline struct sm2_region *sm2_peer_region(struct sm2_ep *ep, int id)
 
 	return sm2_mmap_ep_region(&av->mmap, id);
 }
-
-bool sm2_adjust_multi_recv(struct sm2_srx_ctx *srx,
-			   struct fi_peer_rx_entry *rx_entry, size_t len);
-void sm2_init_rx_entry(struct sm2_rx_entry *entry, const struct iovec *iov,
-		       void **desc, size_t count, fi_addr_t addr, void *context,
-		       uint64_t tag, uint64_t flags);
-struct sm2_rx_entry *sm2_get_recv_entry(struct sm2_srx_ctx *srx,
-					const struct iovec *iov, void **desc,
-					size_t count, fi_addr_t addr,
-					void *context, uint64_t tag,
-					uint64_t ignore, uint64_t flags);
 
 #endif /* _SM2_H_ */

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -43,8 +43,9 @@
 #include "sm2.h"
 #include "sm2_fifo.h"
 
-extern struct fi_ops_msg sm2_msg_ops, sm2_no_recv_msg_ops, sm2_srx_msg_ops;
-extern struct fi_ops_tagged sm2_tag_ops, sm2_no_recv_tag_ops, sm2_srx_tag_ops;
+extern struct fi_ops_msg sm2_msg_ops, sm2_no_recv_msg_ops;
+extern struct fi_ops_tagged sm2_tag_ops, sm2_no_recv_tag_ops;
+
 int sm2_global_ep_idx = 0;
 
 int sm2_setname(fid_t fid, void *addr, size_t addrlen)
@@ -103,121 +104,60 @@ static struct fi_ops_cm sm2_cm_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
-int sm2_getopt(fid_t fid, int level, int optname, void *optval, size_t *optlen)
+static int sm2_ep_getopt(fid_t fid, int level, int optname, void *optval,
+			 size_t *optlen)
 {
-	struct sm2_ep *sm2_ep =
-		container_of(fid, struct sm2_ep, util_ep.ep_fid);
+	struct sm2_ep *ep = container_of(fid, struct sm2_ep, util_ep.ep_fid);
+	return ep->srx->ops->getopt(&ep->srx->fid, level, optname, optval,
+				    optlen);
+}
 
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
+static int sm2_ep_setopt(fid_t fid, int level, int optname, const void *optval,
+			 size_t optlen)
+{
+	struct sm2_ep *ep = container_of(fid, struct sm2_ep, util_ep.ep_fid);
+	struct util_srx_ctx *srx =
+		util_get_peer_srx(ep->srx)->ep_fid.fid.context;
+
+	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
-	*(size_t *) optval = sm2_get_srx(sm2_ep)->min_multi_recv_size;
-	*optlen = sizeof(size_t);
-
-	return FI_SUCCESS;
-}
-
-int sm2_setopt(fid_t fid, int level, int optname, const void *optval,
-	       size_t optlen)
-{
-	struct sm2_ep *sm2_ep =
-		container_of(fid, struct sm2_ep, util_ep.ep_fid);
-
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
-		return -FI_ENOPROTOOPT;
-
-	sm2_get_srx(sm2_ep)->min_multi_recv_size = *(size_t *) optval;
-
-	return FI_SUCCESS;
-}
-
-static int sm2_match_recv_ctx(struct dlist_entry *item, const void *args)
-{
-	struct sm2_rx_entry *pending_recv;
-
-	pending_recv = container_of(item, struct sm2_rx_entry, peer_entry);
-	return pending_recv->peer_entry.context == args;
-}
-
-static int sm2_ep_cancel_recv(struct sm2_ep *ep, struct sm2_queue *queue,
-			      void *context, uint32_t op)
-{
-	struct sm2_srx_ctx *srx = sm2_get_srx(ep);
-	struct sm2_rx_entry *recv_entry;
-	struct dlist_entry *entry;
-	int ret = 0;
-
-	ofi_spin_lock(&srx->lock);
-	entry = dlist_remove_first_match(&queue->list, sm2_match_recv_ctx,
-					 context);
-	if (entry) {
-		recv_entry =
-			container_of(entry, struct sm2_rx_entry, peer_entry);
-		ret = sm2_write_err_comp(
-			ep->util_ep.rx_cq, recv_entry->peer_entry.context,
-			sm2_rx_cq_flags(op, recv_entry->peer_entry.flags, 0),
-			recv_entry->peer_entry.tag, FI_ECANCELED);
-		ofi_freestack_push(srx->recv_fs, recv_entry);
-		ret = ret ? ret : 1;
+	if (optname == FI_OPT_MIN_MULTI_RECV) {
+		srx->min_multi_recv_size = *(size_t *) optval;
+		return FI_SUCCESS;
 	}
 
-	ofi_spin_unlock(&srx->lock);
-	return ret;
+	if (optname == FI_OPT_CUDA_API_PERMITTED) {
+		if (!hmem_ops[FI_HMEM_CUDA].initialized) {
+			FI_WARN(&sm2_prov, FI_LOG_CORE,
+				"Cannot set option FI_OPT_CUDA_API_PERMITTED "
+				"when cuda library or cuda device not "
+				"available\n");
+			return -FI_EINVAL;
+		}
+		/* our CUDA support relies on the ability to call CUDA API */
+		return *(bool *) optval ? FI_SUCCESS : -FI_EOPNOTSUPP;
+	}
+	return -FI_ENOPROTOOPT;
 }
 
 static ssize_t sm2_ep_cancel(fid_t ep_fid, void *context)
 {
 	struct sm2_ep *ep;
-	int ret;
-
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid);
-
-	ret = sm2_ep_cancel_recv(ep, &sm2_get_srx(ep)->trecv_queue, context,
-				 ofi_op_tagged);
-	if (ret)
-		return (ret < 0) ? ret : 0;
-
-	ret = sm2_ep_cancel_recv(ep, &sm2_get_srx(ep)->recv_queue, context,
-				 ofi_op_msg);
-	return (ret < 0) ? ret : 0;
+	return ep->srx->ops->cancel(&ep->srx->fid, context);
 }
 
 static struct fi_ops_ep sm2_ep_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = sm2_ep_cancel,
-	.getopt = sm2_getopt,
-	.setopt = sm2_setopt,
+	.getopt = sm2_ep_getopt,
+	.setopt = sm2_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,
 	.tx_size_left = fi_no_tx_size_left,
 };
-
-static int sm2_match_msg(struct dlist_entry *item, const void *args)
-{
-	struct sm2_match_attr *attr = (struct sm2_match_attr *) args;
-	struct sm2_rx_entry *recv_entry;
-
-	recv_entry = container_of(item, struct sm2_rx_entry, peer_entry);
-	return sm2_match_id(recv_entry->peer_entry.addr, attr->id);
-}
-
-static int sm2_match_tagged(struct dlist_entry *item, const void *args)
-{
-	struct sm2_match_attr *attr = (struct sm2_match_attr *) args;
-	struct sm2_rx_entry *recv_entry;
-
-	recv_entry = container_of(item, struct sm2_rx_entry, peer_entry);
-	return sm2_match_id(recv_entry->peer_entry.addr, attr->id) &&
-	       sm2_match_tag(recv_entry->peer_entry.tag, recv_entry->ignore,
-			     attr->tag);
-}
-
-static void sm2_init_queue(struct sm2_queue *queue, dlist_func_t *match_func)
-{
-	dlist_init(&queue->list);
-	queue->match_func = match_func;
-}
 
 sm2_gid_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid)
 {
@@ -296,81 +236,6 @@ static ssize_t sm2_do_inject(struct sm2_ep *ep, struct sm2_region *peer_smr,
 	return FI_SUCCESS;
 }
 
-int sm2_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
-{
-	struct sm2_srx_ctx *srx;
-
-	if (flags != FI_RECV || bfid->fclass != FI_CLASS_CQ)
-		return -FI_EINVAL;
-
-	srx = container_of(fid, struct sm2_srx_ctx, peer_srx.ep_fid.fid);
-	srx->cq = container_of(bfid, struct util_cq, cq_fid.fid);
-	ofi_atomic_inc32(&srx->cq->ref);
-	return FI_SUCCESS;
-}
-
-static void sm2_close_recv_queue(struct sm2_srx_ctx *srx,
-				 struct sm2_queue *recv_queue)
-{
-	struct fi_cq_err_entry err_entry;
-	struct sm2_rx_entry *rx_entry;
-	int ret;
-
-	while (!dlist_empty(&recv_queue->list)) {
-		dlist_pop_front(&recv_queue->list, struct sm2_rx_entry,
-				rx_entry, peer_entry);
-
-		memset(&err_entry, 0, sizeof err_entry);
-		err_entry.op_context = rx_entry->peer_entry.context;
-		err_entry.flags = rx_entry->peer_entry.flags;
-		err_entry.tag = rx_entry->peer_entry.tag;
-		err_entry.err = FI_ECANCELED;
-		err_entry.prov_errno = -FI_ECANCELED;
-		ret = srx->cq->peer_cq->owner_ops->writeerr(srx->cq->peer_cq,
-							    &err_entry);
-		if (ret)
-			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-				"Error writing recv entry error to rx cq\n");
-
-		ofi_freestack_push(srx->recv_fs, rx_entry);
-	}
-}
-
-static void sm2_close_unexp_queue(struct sm2_srx_ctx *srx,
-				  struct sm2_queue *unexp_queue)
-{
-	struct sm2_rx_entry *rx_entry;
-
-	while (!dlist_empty(&unexp_queue->list)) {
-		dlist_pop_front(&unexp_queue->list, struct sm2_rx_entry,
-				rx_entry, peer_entry);
-		rx_entry->peer_entry.srx->peer_ops->discard_msg(
-			&rx_entry->peer_entry);
-	}
-}
-
-static int sm2_srx_close(struct fid *fid)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(fid, struct sm2_srx_ctx, peer_srx.ep_fid.fid);
-	if (!srx)
-		return -FI_EINVAL;
-
-	sm2_close_recv_queue(srx, &srx->recv_queue);
-	sm2_close_recv_queue(srx, &srx->trecv_queue);
-
-	sm2_close_unexp_queue(srx, &srx->unexp_msg_queue);
-	sm2_close_unexp_queue(srx, &srx->unexp_tagged_queue);
-
-	ofi_atomic_dec32(&srx->cq->ref);
-	sm2_recv_fs_free(srx->recv_fs);
-	ofi_spin_destroy(&srx->lock);
-	free(srx);
-
-	return FI_SUCCESS;
-}
-
 static void cleanup_shm_resources(struct sm2_ep *ep)
 {
 	struct sm2_xfer_entry *xfer_entry;
@@ -442,7 +307,7 @@ static int sm2_ep_close(struct fid *fid)
 	}
 
 	if (ep->util_ep.ep_fid.msg != &sm2_no_recv_msg_ops)
-		sm2_srx_close(&ep->srx->fid);
+		(void) util_srx_close(&ep->srx->fid);
 
 	if (ep->xfer_ctx_pool)
 		ofi_bufpool_destroy(ep->xfer_ctx_pool);
@@ -452,6 +317,18 @@ static int sm2_ep_close(struct fid *fid)
 	free((void *) ep->name);
 	free(ep);
 	return 0;
+}
+
+int sm2_progress_addr(struct fi_peer_rx_entry *rx_entry)
+{
+	struct sm2_xfer_ctx *xfer_ctx = rx_entry->peer_context;
+	struct sm2_ep *ep = xfer_ctx->ep;
+	struct sm2_av *sm2_av =
+		container_of(ep->util_ep.av, struct sm2_av, util_av);
+
+	rx_entry->addr =
+		sm2_av->reverse_lookup[xfer_ctx->xfer_entry.sender_gid];
+	return rx_entry->addr == FI_ADDR_UNSPEC ? -FI_EAGAIN : FI_SUCCESS;
 }
 
 static int sm2_ep_trywait(void *arg)
@@ -545,192 +422,6 @@ static int sm2_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 	return ret;
 }
 
-bool sm2_adjust_multi_recv(struct sm2_srx_ctx *srx,
-			   struct fi_peer_rx_entry *rx_entry, size_t len)
-{
-	size_t left;
-	void *new_base;
-
-	left = rx_entry->iov[0].iov_len - len;
-
-	new_base = (void *) ((uintptr_t) rx_entry->iov[0].iov_base + len);
-	rx_entry->iov[0].iov_len = left;
-	rx_entry->iov[0].iov_base = new_base;
-	rx_entry->size = left;
-
-	return left < srx->min_multi_recv_size;
-}
-
-static int sm2_get_msg(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
-		       struct fi_peer_rx_entry **rx_entry)
-{
-	struct sm2_rx_entry *sm2_entry;
-	struct sm2_srx_ctx *srx_ctx;
-	struct sm2_match_attr match_attr;
-	struct dlist_entry *dlist_entry;
-	struct sm2_rx_entry *owner_entry;
-	int ret;
-
-	srx_ctx = srx->ep_fid.fid.context;
-	ofi_spin_lock(&srx_ctx->lock);
-
-	match_attr.id = addr;
-
-	dlist_entry = dlist_find_first_match(&srx_ctx->recv_queue.list,
-					     srx_ctx->recv_queue.match_func,
-					     &match_attr);
-	if (!dlist_entry) {
-		sm2_entry = sm2_alloc_rx_entry(srx_ctx);
-		if (!sm2_entry) {
-			ret = -FI_ENOMEM;
-		} else {
-			sm2_entry->peer_entry.owner_context = NULL;
-			sm2_entry->peer_entry.addr = addr;
-			sm2_entry->peer_entry.size = size;
-			sm2_entry->peer_entry.srx = srx;
-			*rx_entry = &sm2_entry->peer_entry;
-			ret = -FI_ENOENT;
-		}
-		goto out;
-	}
-
-	*rx_entry = (struct fi_peer_rx_entry *) dlist_entry;
-
-	if ((*rx_entry)->flags & FI_MULTI_RECV) {
-		owner_entry = container_of(*rx_entry, struct sm2_rx_entry,
-					   peer_entry);
-		sm2_entry = sm2_get_recv_entry(
-			srx_ctx, owner_entry->iov, owner_entry->desc,
-			owner_entry->peer_entry.count, addr,
-			owner_entry->peer_entry.context,
-			owner_entry->peer_entry.tag, owner_entry->ignore,
-			owner_entry->peer_entry.flags & (~FI_MULTI_RECV));
-		if (!sm2_entry) {
-			ret = -FI_ENOMEM;
-			goto out;
-		}
-
-		if (sm2_adjust_multi_recv(srx_ctx, &owner_entry->peer_entry,
-					  size))
-			dlist_remove(dlist_entry);
-
-		sm2_entry->peer_entry.owner_context = owner_entry;
-		*rx_entry = &sm2_entry->peer_entry;
-		owner_entry->multi_recv_ref++;
-	} else {
-		dlist_remove(dlist_entry);
-	}
-
-	(*rx_entry)->srx = srx;
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx_ctx->lock);
-	return ret;
-}
-
-static int sm2_get_tag(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
-		       uint64_t tag, struct fi_peer_rx_entry **rx_entry)
-{
-	struct sm2_rx_entry *sm2_entry;
-	struct sm2_srx_ctx *srx_ctx;
-	struct sm2_match_attr match_attr;
-	struct dlist_entry *dlist_entry;
-	int ret;
-
-	srx_ctx = srx->ep_fid.fid.context;
-	ofi_spin_lock(&srx_ctx->lock);
-
-	match_attr.id = addr;
-	match_attr.tag = tag;
-
-	dlist_entry = dlist_find_first_match(&srx_ctx->trecv_queue.list,
-					     srx_ctx->trecv_queue.match_func,
-					     &match_attr);
-	if (!dlist_entry) {
-		sm2_entry = sm2_alloc_rx_entry(srx_ctx);
-		if (!sm2_entry) {
-			ret = -FI_ENOMEM;
-		} else {
-			sm2_entry->peer_entry.owner_context = NULL;
-			sm2_entry->peer_entry.addr = addr;
-			sm2_entry->peer_entry.size = size;
-			sm2_entry->peer_entry.tag = tag;
-			sm2_entry->peer_entry.srx = srx;
-			*rx_entry = &sm2_entry->peer_entry;
-			ret = -FI_ENOENT;
-		}
-		goto out;
-	}
-	dlist_remove(dlist_entry);
-
-	*rx_entry = (struct fi_peer_rx_entry *) dlist_entry;
-	(*rx_entry)->srx = srx;
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx_ctx->lock);
-	return ret;
-}
-
-static int sm2_queue_msg(struct fi_peer_rx_entry *rx_entry)
-{
-	struct sm2_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
-
-	ofi_spin_lock(&srx_ctx->lock);
-	dlist_insert_tail((struct dlist_entry *) rx_entry,
-			  &srx_ctx->unexp_msg_queue.list);
-	ofi_spin_unlock(&srx_ctx->lock);
-	return 0;
-}
-
-static int sm2_queue_tag(struct fi_peer_rx_entry *rx_entry)
-{
-	struct sm2_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
-
-	ofi_spin_lock(&srx_ctx->lock);
-	dlist_insert_tail((struct dlist_entry *) rx_entry,
-			  &srx_ctx->unexp_tagged_queue.list);
-	ofi_spin_unlock(&srx_ctx->lock);
-	return 0;
-}
-
-static void sm2_free_entry(struct fi_peer_rx_entry *entry)
-{
-	struct sm2_srx_ctx *srx =
-		(struct sm2_srx_ctx *) entry->srx->ep_fid.fid.context;
-	struct sm2_rx_entry *sm2_entry, *owner_entry;
-
-	ofi_spin_lock(&srx->lock);
-	sm2_entry = container_of(entry, struct sm2_rx_entry, peer_entry);
-	if (entry->owner_context) {
-		owner_entry = container_of(entry->owner_context,
-					   struct sm2_rx_entry, peer_entry);
-		if (!--owner_entry->multi_recv_ref &&
-		    owner_entry->peer_entry.size < srx->min_multi_recv_size) {
-			if (ofi_peer_cq_write(srx->cq,
-					      owner_entry->peer_entry.context,
-					      FI_MULTI_RECV, 0, NULL, 0, 0,
-					      FI_ADDR_NOTAVAIL)) {
-				FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-					"unable to write rx MULTI_RECV "
-					"completion\n");
-			}
-			ofi_freestack_push(srx->recv_fs, owner_entry);
-		}
-	}
-
-	ofi_freestack_push(srx->recv_fs, sm2_entry);
-	ofi_spin_unlock(&srx->lock);
-}
-
-static struct fi_ops_srx_owner sm2_srx_owner_ops = {
-	.size = sizeof(struct fi_ops_srx_owner),
-	.get_msg = sm2_get_msg,
-	.get_tag = sm2_get_tag,
-	.queue_msg = sm2_queue_msg,
-	.queue_tag = sm2_queue_tag,
-	.free_entry = sm2_free_entry,
-};
-
 static int sm2_discard(struct fi_peer_rx_entry *rx_entry)
 {
 	struct sm2_xfer_ctx *xfer_ctx = rx_entry->peer_context;
@@ -743,71 +434,11 @@ struct fi_ops_srx_peer sm2_srx_peer_ops = {
 	.size = sizeof(struct fi_ops_srx_peer),
 	.start_msg = sm2_unexp_start,
 	.start_tag = sm2_unexp_start,
+	.progress_msg = sm2_progress_addr,
+	.progress_tag = sm2_progress_addr,
 	.discard_msg = sm2_discard,
 	.discard_tag = sm2_discard,
 };
-
-static struct fi_ops sm2_srx_fid_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = sm2_srx_close,
-	.bind = sm2_srx_bind,
-	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
-};
-
-static struct fi_ops_ep sm2_srx_ops = {
-	.size = sizeof(struct fi_ops_ep),
-	.cancel = sm2_ep_cancel,
-	.getopt = fi_no_getopt,
-	.setopt = fi_no_setopt,
-	.tx_ctx = fi_no_tx_ctx,
-	.rx_ctx = fi_no_rx_ctx,
-	.rx_size_left = fi_no_rx_size_left,
-	.tx_size_left = fi_no_tx_size_left,
-};
-
-static int sm2_ep_srx_context(struct sm2_domain *domain, size_t rx_size,
-			      struct fid_ep **rx_ep)
-{
-	struct sm2_srx_ctx *srx;
-	int ret = FI_SUCCESS;
-
-	srx = calloc(1, sizeof(*srx));
-	if (!srx)
-		return -FI_ENOMEM;
-
-	ret = ofi_spin_init(&srx->lock);
-	if (ret)
-		goto err;
-
-	sm2_init_queue(&srx->recv_queue, sm2_match_msg);
-	sm2_init_queue(&srx->trecv_queue, sm2_match_tagged);
-	sm2_init_queue(&srx->unexp_msg_queue, sm2_match_msg);
-	sm2_init_queue(&srx->unexp_tagged_queue, sm2_match_tagged);
-
-	srx->recv_fs = sm2_recv_fs_create(rx_size, NULL, NULL);
-
-	srx->min_multi_recv_size = SM2_INJECT_SIZE;
-	srx->dir_recv = domain->util_domain.info_domain_caps & FI_DIRECTED_RECV;
-
-	srx->peer_srx.owner_ops = &sm2_srx_owner_ops;
-	srx->peer_srx.peer_ops = &sm2_srx_peer_ops;
-
-	srx->peer_srx.ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
-	srx->peer_srx.ep_fid.fid.context = srx;
-	srx->peer_srx.ep_fid.fid.ops = &sm2_srx_fid_ops;
-	srx->peer_srx.ep_fid.ops = &sm2_srx_ops;
-
-	srx->peer_srx.ep_fid.msg = &sm2_srx_msg_ops;
-	srx->peer_srx.ep_fid.tagged = &sm2_srx_tag_ops;
-	*rx_ep = &srx->peer_srx.ep_fid;
-
-	return FI_SUCCESS;
-
-err:
-	free(srx);
-	return ret;
-}
 
 int sm2_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		    struct fid_ep **rx_ep, void *context)
@@ -823,7 +454,9 @@ int sm2_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		sm2_domain->srx->peer_ops = &sm2_srx_peer_ops;
 		return FI_SUCCESS;
 	}
-	return sm2_ep_srx_context(sm2_domain, attr->size, rx_ep);
+
+	return util_ep_srx_context(&sm2_domain->util_domain, attr->size,
+				   SM2_IOV_LIMIT, SM2_INJECT_SIZE, rx_ep);
 }
 
 static int sm2_ep_ctrl(struct fid *fid, int command, void *arg)
@@ -832,6 +465,7 @@ static int sm2_ep_ctrl(struct fid *fid, int command, void *arg)
 	struct sm2_domain *domain;
 	struct sm2_ep *ep;
 	struct sm2_av *av;
+	struct fid_peer_srx *srx;
 	int ret;
 	sm2_gid_t self_gid;
 
@@ -859,15 +493,26 @@ static int sm2_ep_ctrl(struct fid *fid, int command, void *arg)
 			domain = container_of(ep->util_ep.domain,
 					      struct sm2_domain,
 					      util_domain.domain_fid);
-			ret = sm2_ep_srx_context(domain, ep->rx_size, &ep->srx);
+			ret = util_ep_srx_context(&domain->util_domain,
+						  ep->rx_size, SM2_IOV_LIMIT,
+						  SM2_INJECT_SIZE, &ep->srx);
 			if (ret)
 				return ret;
-			ret = sm2_srx_bind(&ep->srx->fid,
-					   &ep->util_ep.rx_cq->cq_fid.fid,
-					   FI_RECV);
+
+			util_get_peer_srx(ep->srx)->peer_ops =
+				&sm2_srx_peer_ops;
+			ret = util_srx_bind(&ep->srx->fid,
+					    &ep->util_ep.rx_cq->cq_fid.fid,
+					    FI_RECV);
 			if (ret)
 				return ret;
 		} else {
+			srx = calloc(1, sizeof(*srx));
+			srx->peer_ops = &sm2_srx_peer_ops;
+			srx->owner_ops = sm2_get_peer_srx(ep)->owner_ops;
+			srx->ep_fid.fid.context =
+				sm2_get_peer_srx(ep)->ep_fid.fid.context;
+			ep->srx = &srx->ep_fid;
 			ep->util_ep.ep_fid.msg = &sm2_no_recv_msg_ops;
 			ep->util_ep.ep_fid.tagged = &sm2_no_recv_tag_ops;
 		}

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,166 +38,6 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
-struct sm2_rx_entry *sm2_alloc_rx_entry(struct sm2_srx_ctx *srx)
-{
-	if (ofi_freestack_isempty(srx->recv_fs)) {
-		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-			"not enough space to post recv\n");
-		return NULL;
-	}
-
-	return ofi_freestack_pop(srx->recv_fs);
-}
-
-void sm2_init_rx_entry(struct sm2_rx_entry *entry, const struct iovec *iov,
-		       void **desc, size_t count, fi_addr_t addr, void *context,
-		       uint64_t tag, uint64_t flags)
-{
-	memcpy(&entry->iov, iov, sizeof(*iov) * count);
-	if (desc)
-		memcpy(entry->desc, desc, sizeof(*desc) * count);
-
-	entry->peer_entry.iov = entry->iov;
-	entry->peer_entry.desc = entry->desc;
-	entry->peer_entry.count = count;
-	entry->peer_entry.addr = addr;
-	entry->peer_entry.context = context;
-	entry->peer_entry.tag = tag;
-	entry->peer_entry.flags = flags;
-}
-
-struct sm2_rx_entry *sm2_get_recv_entry(struct sm2_srx_ctx *srx,
-					const struct iovec *iov, void **desc,
-					size_t count, fi_addr_t addr,
-					void *context, uint64_t tag,
-					uint64_t ignore, uint64_t flags)
-{
-	struct sm2_rx_entry *entry;
-
-	entry = sm2_alloc_rx_entry(srx);
-	if (!entry)
-		return NULL;
-
-	sm2_init_rx_entry(entry, iov, desc, count, addr, context, tag, flags);
-
-	entry->peer_entry.owner_context = NULL;
-
-	entry->multi_recv_ref = 0;
-	entry->ignore = ignore;
-	entry->err = 0;
-
-	return entry;
-}
-
-static ssize_t sm2_generic_mrecv(struct sm2_srx_ctx *srx,
-				 const struct iovec *iov, void **desc,
-				 size_t iov_count, fi_addr_t addr,
-				 void *context, uint64_t flags)
-{
-	struct sm2_match_attr match_attr;
-	struct sm2_rx_entry *rx_entry, *mrecv_entry;
-	struct dlist_entry *dlist_entry;
-	bool buf_done = false;
-	int ret;
-
-	assert(flags & FI_MULTI_RECV && iov_count == 1);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-
-	ofi_spin_lock(&srx->lock);
-	mrecv_entry = sm2_get_recv_entry(srx, iov, desc, iov_count, addr,
-					 context, 0, 0, flags);
-	if (!mrecv_entry) {
-		ret = -FI_ENOMEM;
-		goto out;
-	}
-	mrecv_entry->peer_entry.size = ofi_total_iov_len(iov, iov_count);
-
-	dlist_entry = dlist_remove_first_match(&srx->unexp_msg_queue.list,
-					       srx->unexp_msg_queue.match_func,
-					       &match_attr);
-	while (dlist_entry) {
-		rx_entry = container_of(dlist_entry, struct sm2_rx_entry,
-					peer_entry);
-		sm2_init_rx_entry(rx_entry, mrecv_entry->peer_entry.iov, desc,
-				  iov_count, addr, context, 0,
-				  flags & (~FI_MULTI_RECV));
-		mrecv_entry->multi_recv_ref++;
-		rx_entry->peer_entry.owner_context = mrecv_entry;
-
-		if (sm2_adjust_multi_recv(srx, &mrecv_entry->peer_entry,
-					  rx_entry->peer_entry.size))
-			buf_done = true;
-
-		ofi_spin_unlock(&srx->lock);
-		ret = srx->peer_srx.peer_ops->start_msg(&rx_entry->peer_entry);
-		if (ret || buf_done)
-			return ret;
-
-		ofi_spin_lock(&srx->lock);
-		dlist_entry = dlist_remove_first_match(
-			&srx->unexp_msg_queue.list,
-			srx->unexp_msg_queue.match_func, &match_attr);
-	}
-
-	dlist_insert_tail((struct dlist_entry *) (&mrecv_entry->peer_entry),
-			  &srx->recv_queue.list);
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx->lock);
-	return ret;
-}
-
-static ssize_t sm2_generic_recv(struct sm2_srx_ctx *srx,
-				const struct iovec *iov, void **desc,
-				size_t iov_count, fi_addr_t addr, void *context,
-				uint64_t tag, uint64_t ignore, uint64_t flags,
-				struct sm2_queue *recv_queue,
-				struct sm2_queue *unexp_queue)
-{
-	struct sm2_match_attr match_attr;
-	struct sm2_rx_entry *rx_entry;
-	struct dlist_entry *dlist_entry;
-	int ret = FI_SUCCESS;
-
-	if (flags & FI_MULTI_RECV) {
-		assert(recv_queue != &srx->trecv_queue);
-		return sm2_generic_mrecv(srx, iov, desc, iov_count, addr,
-					 context, flags);
-	}
-
-	assert(iov_count <= SM2_IOV_LIMIT);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-	match_attr.ignore = ignore;
-	match_attr.tag = tag;
-
-	ofi_spin_lock(&srx->lock);
-	dlist_entry = dlist_remove_first_match(
-		&unexp_queue->list, unexp_queue->match_func, &match_attr);
-	if (!dlist_entry) {
-		rx_entry = sm2_get_recv_entry(srx, iov, desc, iov_count, addr,
-					      context, tag, ignore, flags);
-		if (!rx_entry)
-			ret = -FI_ENOMEM;
-		else
-			dlist_insert_tail(
-				(struct dlist_entry *) (&rx_entry->peer_entry),
-				&recv_queue->list);
-		ofi_spin_unlock(&srx->lock);
-		return ret;
-	}
-	ofi_spin_unlock(&srx->lock);
-
-	rx_entry = container_of(dlist_entry, struct sm2_rx_entry, peer_entry);
-	sm2_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context, tag,
-			  flags);
-
-	return srx->peer_srx.peer_ops->start_msg(&rx_entry->peer_entry);
-}
-
 static ssize_t sm2_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			   uint64_t flags)
 {
@@ -205,11 +45,9 @@ static ssize_t sm2_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(sm2_get_srx(ep), msg->msg_iov, msg->desc,
-				msg->iov_count, msg->addr, msg->context, 0, 0,
-				flags | ep->util_ep.rx_msg_flags,
-				&sm2_get_srx(ep)->recv_queue,
-				&sm2_get_srx(ep)->unexp_msg_queue);
+	return util_srx_generic_recv(ep->srx, msg->msg_iov, msg->desc,
+				     msg->iov_count, msg->addr, msg->context,
+				     flags | ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t sm2_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -220,10 +58,8 @@ static ssize_t sm2_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(sm2_get_srx(ep), iov, desc, count, src_addr,
-				context, 0, 0, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->recv_queue,
-				&sm2_get_srx(ep)->unexp_msg_queue);
+	return util_srx_generic_recv(ep->srx, iov, desc, count, src_addr,
+				     context, sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_recv(struct fid_ep *ep_fid, void *buf, size_t len,
@@ -237,52 +73,8 @@ static ssize_t sm2_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return sm2_generic_recv(sm2_get_srx(ep), &iov, &desc, 1, src_addr,
-				context, 0, 0, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->recv_queue,
-				&sm2_get_srx(ep)->unexp_msg_queue);
-}
-
-static ssize_t sm2_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-			       uint64_t flags)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, msg->msg_iov, msg->desc, msg->iov_count,
-				msg->addr, msg->context, 0, 0,
-				flags | srx->rx_msg_flags, &srx->recv_queue,
-				&srx->unexp_msg_queue);
-}
-
-static ssize_t sm2_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
-			     void **desc, size_t count, fi_addr_t src_addr,
-			     void *context)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, iov, desc, count, src_addr, context, 0, 0,
-				srx->rx_op_flags, &srx->recv_queue,
-				&srx->unexp_msg_queue);
-}
-
-static ssize_t sm2_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
-			    void *desc, fi_addr_t src_addr, void *context)
-{
-	struct iovec iov;
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	iov.iov_base = buf;
-	iov.iov_len = len;
-
-	return sm2_generic_recv(srx, &iov, &desc, 1, src_addr, context, 0, 0,
-				srx->rx_op_flags, &srx->recv_queue,
-				&srx->unexp_msg_queue);
+	return util_srx_generic_recv(ep->srx, &iov, &desc, 1, src_addr, context,
+				     sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
@@ -458,19 +250,6 @@ struct fi_ops_msg sm2_no_recv_msg_ops = {
 	.injectdata = sm2_injectdata,
 };
 
-struct fi_ops_msg sm2_srx_msg_ops = {
-	.size = sizeof(struct fi_ops_tagged),
-	.recv = sm2_srx_recv,
-	.recvv = sm2_srx_recvv,
-	.recvmsg = sm2_srx_recvmsg,
-	.send = fi_no_msg_send,
-	.sendv = fi_no_msg_sendv,
-	.sendmsg = fi_no_msg_sendmsg,
-	.inject = fi_no_msg_inject,
-	.senddata = fi_no_msg_senddata,
-	.injectdata = fi_no_msg_injectdata,
-};
-
 static ssize_t sm2_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 			 void *desc, fi_addr_t src_addr, uint64_t tag,
 			 uint64_t ignore, void *context)
@@ -483,10 +262,9 @@ static ssize_t sm2_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return sm2_generic_recv(sm2_get_srx(ep), &iov, &desc, 1, src_addr,
-				context, tag, ignore, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->trecv_queue,
-				&sm2_get_srx(ep)->unexp_tagged_queue);
+	return util_srx_generic_trecv(ep->srx, &iov, &desc, 1, src_addr,
+				      context, tag, ignore,
+				      sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -497,10 +275,9 @@ static ssize_t sm2_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(sm2_get_srx(ep), iov, desc, count, src_addr,
-				context, tag, ignore, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->trecv_queue,
-				&sm2_get_srx(ep)->unexp_tagged_queue);
+	return util_srx_generic_trecv(ep->srx, iov, desc, count, src_addr,
+				      context, tag, ignore,
+				      sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_trecvmsg(struct fid_ep *ep_fid,
@@ -510,54 +287,10 @@ static ssize_t sm2_trecvmsg(struct fid_ep *ep_fid,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(
-		sm2_get_srx(ep), msg->msg_iov, msg->desc, msg->iov_count,
-		msg->addr, msg->context, msg->tag, msg->ignore,
-		flags | ep->util_ep.rx_msg_flags, &sm2_get_srx(ep)->trecv_queue,
-		&sm2_get_srx(ep)->unexp_tagged_queue);
-}
-
-static ssize_t sm2_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
-			     void *desc, fi_addr_t src_addr, uint64_t tag,
-			     uint64_t ignore, void *context)
-{
-	struct iovec iov;
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	iov.iov_base = buf;
-	iov.iov_len = len;
-
-	return sm2_generic_recv(srx, &iov, &desc, 1, src_addr, context, tag,
-				ignore, srx->rx_op_flags, &srx->trecv_queue,
-				&srx->unexp_tagged_queue);
-}
-
-static ssize_t sm2_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
-			      void **desc, size_t count, fi_addr_t src_addr,
-			      uint64_t tag, uint64_t ignore, void *context)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, iov, desc, count, src_addr, context, tag,
-				ignore, srx->rx_op_flags, &srx->trecv_queue,
-				&srx->unexp_tagged_queue);
-}
-
-static ssize_t sm2_srx_trecvmsg(struct fid_ep *ep_fid,
-				const struct fi_msg_tagged *msg, uint64_t flags)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, msg->msg_iov, msg->desc, msg->iov_count,
-				msg->addr, msg->context, msg->tag, msg->ignore,
-				flags | srx->rx_msg_flags, &srx->trecv_queue,
-				&srx->unexp_tagged_queue);
+	return util_srx_generic_trecv(ep->srx, msg->msg_iov, msg->desc,
+				      msg->iov_count, msg->addr, msg->context,
+				      msg->tag, msg->ignore,
+				      flags | ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t sm2_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -653,19 +386,6 @@ struct fi_ops_tagged sm2_no_recv_tag_ops = {
 	.recvmsg = fi_no_tagged_recvmsg,
 	.send = sm2_tsend,
 	.sendv = sm2_tsendv,
-	.sendmsg = sm2_tsendmsg,
-	.inject = sm2_tinject,
-	.senddata = sm2_tsenddata,
-	.injectdata = sm2_tinjectdata,
-};
-
-struct fi_ops_tagged sm2_srx_tag_ops = {
-	.size = sizeof(struct fi_ops_tagged),
-	.recv = sm2_srx_trecv,
-	.recvv = sm2_srx_trecvv,
-	.recvmsg = sm2_srx_trecvmsg,
-	.send = fi_no_tagged_send,
-	.sendv = fi_no_tagged_sendv,
 	.sendmsg = sm2_tsendmsg,
 	.inject = sm2_tinject,
 	.senddata = sm2_tsenddata,

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -173,7 +173,11 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 			if (ret)
 				return ret;
 
-			ret = peer_srx->owner_ops->queue_tag(rx_entry);
+			if (rx_entry->addr == FI_ADDR_UNSPEC)
+				ret = peer_srx->owner_ops->queue_tag_progress(
+					rx_entry);
+			else
+				ret = peer_srx->owner_ops->queue_tag(rx_entry);
 			goto out;
 		}
 	} else {
@@ -186,7 +190,11 @@ static int sm2_progress_recv_msg(struct sm2_ep *ep,
 			if (ret)
 				return ret;
 
-			ret = peer_srx->owner_ops->queue_msg(rx_entry);
+			if (rx_entry->addr == FI_ADDR_UNSPEC)
+				ret = peer_srx->owner_ops->queue_msg_progress(
+					rx_entry);
+			else
+				ret = peer_srx->owner_ops->queue_msg(rx_entry);
 			goto out;
 		}
 	}


### PR DESCRIPTION
sm2 has internal receive queues that can now be replaced with the generic util_srx

This also adds the missing progress functions needed for sm2 to work with the util_srx progress support