### PR TITLE
prov/sm2: free rx_entry on error

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ common_srcs =				\
 	prov/util/src/util_mr_map.c	\
 	prov/util/src/util_ns.c		\
 	prov/util/src/util_shm.c	\
+	prov/util/src/util_srx.c	\
 	prov/util/src/util_mem_monitor.c\
 	prov/util/src/util_mem_hooks.c	\
 	prov/util/src/util_mr_cache.c	\

--- a/fabtests/test_configs/shm/shm.exclude
+++ b/fabtests/test_configs/shm/shm.exclude
@@ -13,7 +13,6 @@ poll
 
 # Exclude tests with unsupported capabilities
 -k
-rdm_tagged_peek
 cm_data
 trigger
 shared_ctx

--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -180,9 +180,9 @@ ofi_array_init(struct ofi_dyn_arr *arr, size_t item_size,
 
 int ofi_array_grow(struct ofi_dyn_arr *arr, int index);
 /* Returning non-zero from callback breaks iteration */
-void ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
-		    int (*callback)(struct ofi_dyn_arr *arr, void *item,
-				    void *context));
+int ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
+		   int (*callback)(struct ofi_dyn_arr *arr, void *item,
+				   void *context));
 void ofi_array_destroy(struct ofi_dyn_arr *arr);
 
 static inline char *ofi_array_chunk(struct ofi_dyn_arr *arr, int index)

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -199,6 +199,7 @@ struct util_domain {
 	struct dlist_entry	list_entry;
 	struct util_fabric	*fabric;
 	struct util_eq		*eq;
+	struct fid_peer_srx	*srx;
 
 	struct ofi_genlock	lock;
 	ofi_atomic32_t		ref;
@@ -1215,7 +1216,73 @@ enum {
 	OFI_OPT_TCP_FI_ADDR = -FI_PROV_SPECIFIC_TCP
 };
 
+struct util_rx_entry {
+	struct fi_peer_rx_entry	peer_entry; /* entry used for per-peer/unspec */
+	struct dlist_entry	entry; /* entry used for all list */
+	uint64_t		seq_no;
+	uint64_t		ignore;
+	int			multi_recv_ref;
+};
 
+struct util_srx_ctx;
+
+typedef void(*ofi_update_func_t)(struct util_srx_ctx *srx,
+				 struct util_rx_entry *rx_entry);
+
+struct util_srx_ctx {
+	struct fid_peer_srx	peer_srx;
+	bool			dir_recv;
+	size_t			min_multi_recv_size;
+	uint64_t		rx_op_flags;
+	uint64_t		rx_msg_flags;
+	size_t			iov_limit;
+	ofi_update_func_t	update_func;
+
+	struct util_cq		*cq;
+
+	uint64_t		rx_seq_no;
+	struct slist		msg_queue;
+	struct slist		tag_queue;
+	struct ofi_dyn_arr	src_recv_queues;
+	struct ofi_dyn_arr	src_trecv_queues;
+
+	struct dlist_entry	unspec_unexp_msg_queue;
+	struct dlist_entry	unspec_unexp_tag_queue;
+
+	struct dlist_entry	all_unexp_msg;
+	struct dlist_entry	all_unexp_tag;
+	struct ofi_dyn_arr	src_unexp_msg_queues;
+	struct ofi_dyn_arr	src_unexp_tag_queues;
+
+	struct ofi_bufpool	*rx_pool;
+	ofi_mutex_t		lock;
+	ofi_mutex_lock_t	lock_acquire;
+	ofi_mutex_unlock_t	lock_release;
+};
+
+struct util_match_attr {
+	fi_addr_t	addr;
+	uint64_t	tag;
+	uint64_t	ignore;
+};
+
+static inline struct fid_peer_srx *util_get_peer_srx(struct fid_ep *rx_ep)
+{
+	return (struct fid_peer_srx *) rx_ep->fid.context;
+}
+
+int util_ep_srx_context(struct util_domain *domain, size_t rx_size,
+			size_t iov_limit, size_t default_min_mr,
+			ofi_update_func_t update_func, struct fid_ep **rx_ep);
+int util_srx_close(struct fid *fid);
+int util_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
+ssize_t util_srx_generic_recv(struct fid_ep *ep_fid, const struct iovec *iov,
+			      void **desc, size_t iov_count, fi_addr_t addr,
+			      void *context, uint64_t flags);
+ssize_t util_srx_generic_trecv(struct fid_ep *ep_fid, const struct iovec *iov,
+			       void **desc, size_t iov_count, fi_addr_t addr,
+			       void *context, uint64_t tag, uint64_t ignore,
+			       uint64_t flags);
 #ifdef __cplusplus
 }
 #endif

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -757,6 +757,7 @@
     <ClCompile Include="prov\util\src\util_main.c" />
     <ClCompile Include="prov\util\src\util_mr_map.c" />
     <ClCompile Include="prov\util\src\util_ns.c" />
+    <ClCompile Include="prov\util\src\util_srx.c" />
     <ClCompile Include="prov\util\src\util_pep.c" />
     <ClCompile Include="prov\util\src\util_poll.c" />
     <ClCompile Include="prov\util\src\util_wait.c" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -486,6 +486,9 @@
     <ClCompile Include="prov\util\src\util_ns.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
+   <ClCompile Include="prov\util\src\util_srx.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
     <ClCompile Include="prov\util\src\util_cntr.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>

--- a/man/fi_peer.3.md
+++ b/man/fi_peer.3.md
@@ -415,6 +415,20 @@ struct fi_peer_srx_context {
 The ownership of structure field values and callback functions is similar
 to those defined for peer CQs, relative to owner versus peer ops.
 
+The owner is responsible for acquiring any necessary locks before anything that
+could result in peer callbacks.
+The following functions are progress level functions that need to be under the
+same lock: get_msg(), get_tag(), queue_msg(), queue_tag(), free_entry(),
+start_msg(), start_tag(), discard_msg(), discard_tag(). These functions called
+during functions that drive message progress, like fi_cq_read() or
+posting receives. When an owner calls into a peer's fi_cq_read() to drive peer
+progress, it is the owner's responsibility to acquire the appropriate lock, if
+needed.
+The following functions are domain level functions that need to be under the
+same lock: foreach_unspec_addr(). This function is used outside of message
+progress flow (i.e. during fi_av_insert()).
+
+
 ## fi_peer_rx_entry
 
 fi_peer_rx_entry defines a common receive entry for use between the owner and

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -50,6 +50,15 @@ static int smr_av_close(struct fid *fid)
 	return 0;
 }
 
+
+static fi_addr_t smr_get_addr(struct fi_peer_rx_entry *rx_entry)
+{
+	struct smr_cmd_ctx *cmd_ctx = rx_entry->peer_context;
+
+	return cmd_ctx->ep->region->map->peers[cmd_ctx->cmd.msg.hdr.id].fiaddr;
+}
+
+
 /*
  * Input address: smr name (string)
  * output address: index (fi_addr_t), the output from util_av
@@ -61,6 +70,7 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	struct util_ep *util_ep;
 	struct smr_av *smr_av;
 	struct smr_ep *smr_ep;
+	struct fid_peer_srx *srx;
 	struct dlist_entry *av_entry;
 	fi_addr_t util_addr;
 	int64_t shm_id = -1;
@@ -123,6 +133,8 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			smr_map_to_endpoint(smr_ep->region, shm_id);
 			smr_ep->region->max_sar_buf_per_peer =
 				SMR_MAX_PEERS / smr_av->smr_map->num_peers;
+			srx = smr_get_peer_srx(smr_ep);
+			srx->owner_ops->foreach_unspec_addr(srx, &smr_get_addr);
 		}
 	}
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -42,8 +42,8 @@
 #include "smr.h"
 #include "smr_dsa.h"
 
-extern struct fi_ops_msg smr_msg_ops, smr_no_recv_msg_ops, smr_srx_msg_ops;
-extern struct fi_ops_tagged smr_tag_ops, smr_no_recv_tag_ops, smr_srx_tag_ops;
+extern struct fi_ops_msg smr_msg_ops, smr_no_recv_msg_ops;
+extern struct fi_ops_tagged smr_tag_ops, smr_no_recv_tag_ops;
 extern struct fi_ops_rma smr_rma_ops;
 extern struct fi_ops_atomic smr_atomic_ops;
 DEFINE_LIST(sock_name_list);
@@ -111,32 +111,29 @@ static struct fi_ops_cm smr_cm_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
-int smr_getopt(fid_t fid, int level, int optname,
-	       void *optval, size_t *optlen)
+int smr_ep_getopt(fid_t fid, int level, int optname, void *optval,
+		  size_t *optlen)
 {
 	struct smr_ep *smr_ep =
 		container_of(fid, struct smr_ep, util_ep.ep_fid);
 
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
-		return -FI_ENOPROTOOPT;
-
-	*(size_t *)optval = smr_get_smr_srx(smr_ep)->min_multi_recv_size;
-	*optlen = sizeof(size_t);
-
-	return FI_SUCCESS;
+	return smr_ep->srx->ops->getopt(&smr_ep->srx->fid, level, optname,
+					optval, optlen);
 }
 
-int smr_setopt(fid_t fid, int level, int optname,
-	       const void *optval, size_t optlen)
+int smr_ep_setopt(fid_t fid, int level, int optname, const void *optval,
+		  size_t optlen)
 {
 	struct smr_ep *smr_ep =
 		container_of(fid, struct smr_ep, util_ep.ep_fid);
+	struct util_srx_ctx *srx;
 
 	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
 	if (optname == FI_OPT_MIN_MULTI_RECV) {
-		smr_get_smr_srx(smr_ep)->min_multi_recv_size = *(size_t *)optval;
+		srx = util_get_peer_srx(smr_ep->srx)->ep_fid.fid.context;
+		srx->min_multi_recv_size = *(size_t *)optval;
 		return FI_SUCCESS;
 	}
 
@@ -155,61 +152,19 @@ int smr_setopt(fid_t fid, int level, int optname,
 	return -FI_ENOPROTOOPT;
 }
 
-static int smr_match_recv_ctx(struct dlist_entry *item, const void *args)
-{
-	struct smr_rx_entry *pending_recv;
-
-	pending_recv = container_of(item, struct smr_rx_entry, peer_entry);
-	return pending_recv->peer_entry.context == args;
-}
-
-static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
-			      void *context, uint32_t op)
-{
-	struct smr_srx_ctx *srx = smr_get_smr_srx(ep);
-	struct smr_rx_entry *recv_entry;
-	struct dlist_entry *entry;
-	int ret = 0;
-
-	ofi_spin_lock(&srx->lock);
-	entry = dlist_remove_first_match(&queue->list, smr_match_recv_ctx,
-					 context);
-	if (entry) {
-		recv_entry = container_of(entry, struct smr_rx_entry, peer_entry);
-		ret = smr_write_err_comp(ep->util_ep.rx_cq,
-			recv_entry->peer_entry.context,
-			smr_rx_cq_flags(op, recv_entry->peer_entry.flags, 0),
-			recv_entry->peer_entry.tag, FI_ECANCELED);
-		ofi_freestack_push(srx->recv_fs, recv_entry);
-		ret = ret ? ret : 1;
-	}
-
-	ofi_spin_unlock(&srx->lock);
-	return ret;
-}
-
 static ssize_t smr_ep_cancel(fid_t ep_fid, void *context)
 {
 	struct smr_ep *ep;
-	int ret;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid);
-
-	ret = smr_ep_cancel_recv(ep, &smr_get_smr_srx(ep)->trecv_queue, context,
-				 ofi_op_tagged);
-	if (ret)
-		return (ret < 0) ? ret : 0;
-
-	ret = smr_ep_cancel_recv(ep, &smr_get_smr_srx(ep)->recv_queue, context,
-				 ofi_op_msg);
-	return (ret < 0) ? ret : 0;
+	return ep->srx->ops->cancel(&ep->srx->fid, context);
 }
 
 static struct fi_ops_ep smr_ep_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = smr_ep_cancel,
-	.getopt = smr_getopt,
-	.setopt = smr_setopt,
+	.getopt = smr_ep_getopt,
+	.setopt = smr_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,
@@ -268,33 +223,6 @@ int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)
 	smr_send_name(ep, id);
 
 	return -1;
-}
-
-static int smr_match_msg(struct dlist_entry *item, const void *args)
-{
-	struct smr_match_attr *attr = (struct smr_match_attr *)args;
-	struct smr_rx_entry *recv_entry;
-
-	recv_entry = container_of(item, struct smr_rx_entry, peer_entry);
-	return smr_match_id(recv_entry->peer_entry.addr, attr->id);
-}
-
-static int smr_match_tagged(struct dlist_entry *item, const void *args)
-{
-	struct smr_match_attr *attr = (struct smr_match_attr *)args;
-	struct smr_rx_entry *recv_entry;
-
-	recv_entry = container_of(item, struct smr_rx_entry, peer_entry);
-	return smr_match_id(recv_entry->peer_entry.addr, attr->id) &&
-	       smr_match_tag(recv_entry->peer_entry.tag, recv_entry->ignore,
-			     attr->tag);
-}
-
-static void smr_init_queue(struct smr_queue *queue,
-			   dlist_func_t *match_func)
-{
-	dlist_init(&queue->list);
-	queue->match_func = match_func;
 }
 
 void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
@@ -850,79 +778,6 @@ static void smr_cleanup_epoll(struct smr_sock_info *sock_info)
 	ofi_epoll_close(sock_info->epollfd);
 }
 
-int smr_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
-{
-	struct smr_srx_ctx *srx;
-
-	if (flags != FI_RECV || bfid->fclass != FI_CLASS_CQ)
-		return -FI_EINVAL;
-
-	srx = container_of(fid, struct smr_srx_ctx, peer_srx.ep_fid.fid);
-	srx->cq = container_of(bfid, struct util_cq, cq_fid.fid);
-	ofi_atomic_inc32(&srx->cq->ref);
-	return FI_SUCCESS;
-}
-
-static void smr_close_recv_queue(struct smr_srx_ctx *srx,
-				 struct smr_queue *recv_queue)
-{
-	struct fi_cq_err_entry err_entry;
-	struct smr_rx_entry *rx_entry;
-	int ret;
-
-	while (!dlist_empty(&recv_queue->list)) {
-		dlist_pop_front(&recv_queue->list, struct smr_rx_entry,
-				rx_entry, peer_entry);
-
-		memset(&err_entry, 0, sizeof err_entry);
-		err_entry.op_context = rx_entry->peer_entry.context;
-		err_entry.flags = rx_entry->peer_entry.flags;
-		err_entry.tag = rx_entry->peer_entry.tag;
-		err_entry.err = FI_ECANCELED;
-		err_entry.prov_errno = -FI_ECANCELED;
-		ret = srx->cq->peer_cq->owner_ops->writeerr(srx->cq->peer_cq, &err_entry);
-		if (ret)
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"Error writing recv entry error to rx cq\n");
-
-		ofi_freestack_push(srx->recv_fs, rx_entry);
-	}
-}
-
-static int smr_srx_close(struct fid *fid)
-{
-	struct smr_srx_ctx *srx;
-	struct smr_rx_entry *rx_entry;
-
-	srx = container_of(fid, struct smr_srx_ctx, peer_srx.ep_fid.fid);
-	if (!srx)
-		return -FI_EINVAL;
-
-	smr_close_recv_queue(srx, &srx->recv_queue);
-	smr_close_recv_queue(srx, &srx->trecv_queue);
-
-	while (!dlist_empty(&srx->unexp_msg_queue.list)) {
-		dlist_pop_front(&srx->unexp_msg_queue.list, struct smr_rx_entry,
-				rx_entry, peer_entry);
-		rx_entry->peer_entry.srx->peer_ops->discard_msg(
-							&rx_entry->peer_entry);
-	}
-
-	while (!dlist_empty(&srx->unexp_tagged_queue.list)) {
-		dlist_pop_front(&srx->unexp_tagged_queue.list,
-				struct smr_rx_entry, rx_entry, peer_entry);
-		rx_entry->peer_entry.srx->peer_ops->discard_tag(
-							&rx_entry->peer_entry);
-	}
-
-	ofi_atomic_dec32(&srx->cq->ref);
-	smr_recv_fs_free(srx->recv_fs);
-	ofi_spin_destroy(&srx->lock);
-	free(srx);
-
-	return FI_SUCCESS;
-}
-
 static int smr_ep_close(struct fid *fid)
 {
 	struct smr_ep *ep;
@@ -947,7 +802,8 @@ static int smr_ep_close(struct fid *fid)
 		smr_free(ep->region);
 
 	if (ep->util_ep.ep_fid.msg != &smr_no_recv_msg_ops)
-		smr_srx_close(&ep->srx->fid);
+		(void) util_srx_close(&ep->srx->fid);
+
 
 	if (ep->cmd_ctx_pool)
 		ofi_bufpool_destroy(ep->cmd_ctx_pool);
@@ -1337,188 +1193,6 @@ err_out:
 		"Defaulting to SAR for device transfers\n");
 }
 
-bool smr_adjust_multi_recv(struct smr_srx_ctx *srx,
-			   struct fi_peer_rx_entry *rx_entry, size_t len)
-{
-	size_t left;
-	void *new_base;
-
-	left = rx_entry->iov[0].iov_len - len;
-
-	new_base = (void *) ((uintptr_t) rx_entry->iov[0].iov_base + len);
-	rx_entry->iov[0].iov_len = left;
-	rx_entry->iov[0].iov_base = new_base;
-	rx_entry->size = left;
-
-	return left < srx->min_multi_recv_size;
-}
-
-static int smr_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
-		       size_t size, struct fi_peer_rx_entry **rx_entry)
-{
-	struct smr_rx_entry *smr_entry;
-	struct smr_srx_ctx *srx_ctx;
-	struct smr_match_attr match_attr;
-	struct dlist_entry *dlist_entry;
-	struct smr_rx_entry *owner_entry;
-	int ret;
-
-	srx_ctx = srx->ep_fid.fid.context;
-	ofi_spin_lock(&srx_ctx->lock);
-
-	match_attr.id = addr;
-
-	dlist_entry = dlist_find_first_match(&srx_ctx->recv_queue.list,
-					     srx_ctx->recv_queue.match_func,
-					     &match_attr);
-	if (!dlist_entry) {
-		smr_entry = smr_alloc_rx_entry(srx_ctx);
-		if (!smr_entry) {
-			ret = -FI_ENOMEM;
-		} else {
-			smr_entry->peer_entry.owner_context = NULL;
-			smr_entry->peer_entry.addr = addr;
-			smr_entry->peer_entry.size = size;
-			smr_entry->peer_entry.srx = srx;
-			*rx_entry = &smr_entry->peer_entry;
-			ret = -FI_ENOENT;
-		}
-		goto out;
-	}
-
-	*rx_entry = (struct fi_peer_rx_entry *) dlist_entry;
-
-	if ((*rx_entry)->flags & FI_MULTI_RECV) {
-		owner_entry = container_of(*rx_entry, struct smr_rx_entry, peer_entry);
-		smr_entry = smr_get_recv_entry(srx_ctx, owner_entry->iov, owner_entry->desc,
-					     owner_entry->peer_entry.count, addr,
-					     owner_entry->peer_entry.context,
-					     owner_entry->peer_entry.tag,
-					     owner_entry->ignore,
-					     owner_entry->peer_entry.flags & (~FI_MULTI_RECV));
-		if (!smr_entry) {
-			ret = -FI_ENOMEM;
-			goto out;
-		}
-
-		if (smr_adjust_multi_recv(srx_ctx, &owner_entry->peer_entry, size))
-			dlist_remove(dlist_entry);
-
-		smr_entry->peer_entry.owner_context = owner_entry;
-		*rx_entry = &smr_entry->peer_entry;
-		owner_entry->multi_recv_ref++;
-	} else {
-		dlist_remove(dlist_entry);
-	}
-
-	(*rx_entry)->srx = srx;
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx_ctx->lock);
-	return ret;
-}
-
-static int smr_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
-			size_t size, uint64_t tag, struct fi_peer_rx_entry **rx_entry)
-{
-	struct smr_rx_entry *smr_entry;
-	struct smr_srx_ctx *srx_ctx;
-	struct smr_match_attr match_attr;
-	struct dlist_entry *dlist_entry;
-	int ret;
-
-	srx_ctx = srx->ep_fid.fid.context;
-	ofi_spin_lock(&srx_ctx->lock);
-
-	match_attr.id = addr;
-	match_attr.tag = tag;
-
-	dlist_entry = dlist_find_first_match(&srx_ctx->trecv_queue.list,
-					     srx_ctx->trecv_queue.match_func,
-					     &match_attr);
-	if (!dlist_entry) {
-		smr_entry = smr_alloc_rx_entry(srx_ctx);
-		if (!smr_entry) {
-			ret = -FI_ENOMEM;
-		} else {
-			smr_entry->peer_entry.owner_context = NULL;
-			smr_entry->peer_entry.addr = addr;
-			smr_entry->peer_entry.size = size;
-			smr_entry->peer_entry.tag = tag;
-			smr_entry->peer_entry.srx = srx;
-			*rx_entry = &smr_entry->peer_entry;
-			ret = -FI_ENOENT;
-		}
-		goto out;
-	}
-	dlist_remove(dlist_entry);
-
-	*rx_entry = (struct fi_peer_rx_entry *) dlist_entry;
-	(*rx_entry)->srx = srx;
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx_ctx->lock);
-	return ret;
-}
-
-static int smr_queue_msg(struct fi_peer_rx_entry *rx_entry)
-{
-	struct smr_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
-
-	ofi_spin_lock(&srx_ctx->lock);
-	dlist_insert_tail((struct dlist_entry *) rx_entry,
-			  &srx_ctx->unexp_msg_queue.list);
-	ofi_spin_unlock(&srx_ctx->lock);
-	return 0;
-}
-
-static int smr_queue_tag(struct fi_peer_rx_entry *rx_entry)
-{
-	struct smr_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
-
-	ofi_spin_lock(&srx_ctx->lock);
-	dlist_insert_tail((struct dlist_entry *) rx_entry,
-			  &srx_ctx->unexp_tagged_queue.list);
-	ofi_spin_unlock(&srx_ctx->lock);
-	return 0;
-}
-
-static void smr_free_entry(struct fi_peer_rx_entry *entry)
-{
-	struct smr_srx_ctx *srx = (struct smr_srx_ctx *) entry->srx->ep_fid.fid.context;
-	struct smr_rx_entry *smr_entry, *owner_entry;
-
-	ofi_spin_lock(&srx->lock);
-	smr_entry = container_of(entry, struct smr_rx_entry, peer_entry);
-	if (entry->owner_context) {
-		owner_entry = container_of(entry->owner_context,
-					   struct smr_rx_entry, peer_entry);
-		if (!--owner_entry->multi_recv_ref &&
-		    owner_entry->peer_entry.size < srx->min_multi_recv_size) {
-			if (ofi_peer_cq_write(srx->cq,
-					      owner_entry->peer_entry.context,
-					      FI_MULTI_RECV, 0, NULL, 0, 0,
-					      FI_ADDR_NOTAVAIL)) {
-				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-					"unable to write rx MULTI_RECV completion\n");
-			}
-			ofi_freestack_push(srx->recv_fs, owner_entry);
-		}
-	}
-
-	ofi_freestack_push(srx->recv_fs, smr_entry);
-	ofi_spin_unlock(&srx->lock);
-}
-
-static struct fi_ops_srx_owner smr_srx_owner_ops = {
-	.size = sizeof(struct fi_ops_srx_owner),
-	.get_msg = smr_get_msg,
-	.get_tag = smr_get_tag,
-	.queue_msg = smr_queue_msg,
-	.queue_tag = smr_queue_tag,
-	.free_entry = smr_free_entry,
-};
-
 static int smr_discard(struct fi_peer_rx_entry *rx_entry)
 {
 	struct smr_cmd_ctx *cmd_ctx = rx_entry->peer_context;
@@ -1535,66 +1209,10 @@ struct fi_ops_srx_peer smr_srx_peer_ops = {
 	.discard_tag = smr_discard,
 };
 
-static struct fi_ops smr_srx_fid_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = smr_srx_close,
-	.bind = smr_srx_bind,
-	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
-};
-
-static struct fi_ops_ep smr_srx_ops = {
-	.size = sizeof(struct fi_ops_ep),
-	.cancel = smr_ep_cancel,
-	.getopt = fi_no_getopt,
-	.setopt = fi_no_setopt,
-	.tx_ctx = fi_no_tx_ctx,
-	.rx_ctx = fi_no_rx_ctx,
-	.rx_size_left = fi_no_rx_size_left,
-	.tx_size_left = fi_no_tx_size_left,
-};
-
-static int smr_ep_srx_context(struct smr_domain *domain, size_t rx_size,
-			      struct fid_ep **rx_ep)
+static void smr_update(struct util_srx_ctx *srx, struct util_rx_entry *rx_entry)
 {
-	struct smr_srx_ctx *srx;
-	int ret = FI_SUCCESS;
-
-	srx = calloc(1, sizeof(*srx));
-	if (!srx)
-		return -FI_ENOMEM;
-
-	ret = ofi_spin_init(&srx->lock);
-	if (ret)
-		goto err;
-
-	smr_init_queue(&srx->recv_queue, smr_match_msg);
-	smr_init_queue(&srx->trecv_queue, smr_match_tagged);
-	smr_init_queue(&srx->unexp_msg_queue, smr_match_msg);
-	smr_init_queue(&srx->unexp_tagged_queue, smr_match_tagged);
-
-	srx->recv_fs = smr_recv_fs_create(rx_size, NULL, NULL);
-
-	srx->min_multi_recv_size = SMR_INJECT_SIZE;
-	srx->dir_recv = domain->util_domain.info_domain_caps & FI_DIRECTED_RECV;
-
-	srx->peer_srx.owner_ops = &smr_srx_owner_ops;
-	srx->peer_srx.peer_ops = &smr_srx_peer_ops;
-
-	srx->peer_srx.ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
-	srx->peer_srx.ep_fid.fid.context = srx;
-	srx->peer_srx.ep_fid.fid.ops = &smr_srx_fid_ops;
-	srx->peer_srx.ep_fid.ops = &smr_srx_ops;
-
-	srx->peer_srx.ep_fid.msg = &smr_srx_msg_ops;
-	srx->peer_srx.ep_fid.tagged = &smr_srx_tag_ops;
-	*rx_ep = &srx->peer_srx.ep_fid;
-
-	return FI_SUCCESS;
-
-err:
-	free(srx);
-	return ret;
+	//no update needed - shm only used as the owner when not used as a peer
+	//by another provider
 }
 
 int smr_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
@@ -1608,7 +1226,9 @@ int smr_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		smr_domain->srx = ((struct fi_peer_srx_context *) (context))->srx;
 		return FI_SUCCESS;
 	}
-	return smr_ep_srx_context(smr_domain, attr->size, rx_ep);
+	return util_ep_srx_context(&smr_domain->util_domain, attr->size,
+				   SMR_IOV_LIMIT, SMR_INJECT_SIZE,
+				   &smr_update, rx_ep);
 }
 
 static int smr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
@@ -1662,6 +1282,7 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 	struct smr_domain *domain;
 	struct smr_ep *ep;
 	struct smr_av *av;
+	struct fid_peer_srx *srx;
 	int ret;
 
 	ep = container_of(fid, struct smr_ep, util_ep.ep_fid.fid);
@@ -1698,16 +1319,25 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 			domain = container_of(ep->util_ep.domain,
 					      struct smr_domain,
 					      util_domain.domain_fid);
-			ret = smr_ep_srx_context(domain, ep->rx_size,
-						 &ep->srx);
+			ret = util_ep_srx_context(&domain->util_domain,
+					ep->rx_size, SMR_IOV_LIMIT,
+					SMR_INJECT_SIZE, &smr_update, &ep->srx);
 			if (ret)
 				return ret;
-			ret = smr_srx_bind(&ep->srx->fid,
+
+			util_get_peer_srx(ep->srx)->peer_ops = &smr_srx_peer_ops;
+			ret = util_srx_bind(&ep->srx->fid,
 					   &ep->util_ep.rx_cq->cq_fid.fid,
 					   FI_RECV);
 			if (ret)
 				return ret;
 		} else {
+			srx = calloc(1, sizeof(*srx));
+			srx->peer_ops = &smr_srx_peer_ops;
+			srx->owner_ops = smr_get_peer_srx(ep)->owner_ops;
+			srx->ep_fid.fid.context =
+				smr_get_peer_srx(ep)->ep_fid.fid.context;
+			ep->srx = &srx->ep_fid;
 			ep->util_ep.ep_fid.msg = &smr_no_recv_msg_ops;
 			ep->util_ep.ep_fid.tagged = &smr_no_recv_tag_ops;
 		}

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -38,171 +38,16 @@
 #include "ofi_iov.h"
 #include "smr.h"
 
-struct smr_rx_entry *smr_alloc_rx_entry(struct smr_srx_ctx *srx)
-{
-	if (ofi_freestack_isempty(srx->recv_fs)) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"not enough space to post recv\n");
-		return NULL;
-	}
-
-	return ofi_freestack_pop(srx->recv_fs);
-}
-
-void smr_init_rx_entry(struct smr_rx_entry *entry, const struct iovec *iov,
-		       void **desc, size_t count, fi_addr_t addr,
-		       void *context, uint64_t tag, uint64_t flags)
-{
-	memcpy(&entry->iov, iov, sizeof(*iov) * count);
-	if (desc)
-		memcpy(entry->desc, desc, sizeof(*desc) * count);
-
-	entry->peer_entry.iov = entry->iov;
-	entry->peer_entry.desc = entry->desc;
-	entry->peer_entry.count = count;
-	entry->peer_entry.addr = addr;
-	entry->peer_entry.context = context;
-	entry->peer_entry.tag = tag;
-	entry->peer_entry.flags = flags;
-}
-
-struct smr_rx_entry *smr_get_recv_entry(struct smr_srx_ctx *srx,
-		const struct iovec *iov, void **desc, size_t count,
-		fi_addr_t addr, void *context, uint64_t tag, uint64_t ignore,
-		uint64_t flags)
-{
-	struct smr_rx_entry *entry;
-
-	entry = smr_alloc_rx_entry(srx);
-	if (!entry)
-		return NULL;
-
-	smr_init_rx_entry(entry, iov, desc, count, addr,
-			  context, tag, flags);
-
-	entry->peer_entry.owner_context = NULL;
-
-	entry->multi_recv_ref = 0;
-	entry->ignore = ignore;
-	entry->err = 0;
-
-	return entry;
-}
-
-static ssize_t smr_generic_mrecv(struct smr_srx_ctx *srx,
-		const struct iovec *iov, void **desc, size_t iov_count,
-		fi_addr_t addr, void *context, uint64_t flags)
-{
-	struct smr_match_attr match_attr;
-	struct smr_rx_entry *rx_entry, *mrecv_entry;
-	struct dlist_entry *dlist_entry;
-	bool buf_done = false;
-	int ret;
-
-	assert(flags & FI_MULTI_RECV && iov_count == 1);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-
-	ofi_spin_lock(&srx->lock);
-	mrecv_entry = smr_get_recv_entry(srx, iov, desc, iov_count, addr,
-					 context, 0, 0, flags);
-	if (!mrecv_entry) {
-		ret = -FI_ENOMEM;
-		goto out;
-	}
-	mrecv_entry->peer_entry.size = ofi_total_iov_len(iov, iov_count);
-
-	dlist_entry = dlist_remove_first_match(&srx->unexp_msg_queue.list,
-					       srx->unexp_msg_queue.match_func,
-					       &match_attr);
-	while (dlist_entry) {
-		rx_entry = container_of(dlist_entry, struct smr_rx_entry,
-					peer_entry);
-		smr_init_rx_entry(rx_entry, mrecv_entry->peer_entry.iov, desc,
-				  iov_count, addr, context, 0,
-				  flags & (~FI_MULTI_RECV));
-		mrecv_entry->multi_recv_ref++;
-		rx_entry->peer_entry.owner_context = mrecv_entry;
-
-		if (smr_adjust_multi_recv(srx, &mrecv_entry->peer_entry,
-					  rx_entry->peer_entry.size))
-			buf_done = true;
-
-		ofi_spin_unlock(&srx->lock);
-		ret = rx_entry->peer_entry.srx->peer_ops->start_msg(
-							&rx_entry->peer_entry);
-		if (ret || buf_done)
-			return ret;
-
-		ofi_spin_lock(&srx->lock);
-		dlist_entry = dlist_remove_first_match(&srx->unexp_msg_queue.list,
-						       srx->unexp_msg_queue.match_func,
-						       &match_attr);
-	}
-
-	dlist_insert_tail((struct dlist_entry *) (&mrecv_entry->peer_entry),
-			  &srx->recv_queue.list);
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx->lock);
-	return ret;
-}
-
-static ssize_t smr_generic_recv(struct smr_srx_ctx *srx,
-		const struct iovec *iov, void **desc, size_t iov_count,
-		fi_addr_t addr, void *context, uint64_t flags)
-{
-	struct smr_match_attr match_attr;
-	struct smr_rx_entry *rx_entry;
-	struct dlist_entry *dlist_entry;
-	int ret = FI_SUCCESS;
-
-	if (flags & FI_MULTI_RECV)
-		return smr_generic_mrecv(srx, iov, desc, iov_count, addr,
-					 context, flags);
-
-	assert(iov_count <= SMR_IOV_LIMIT);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-
-	ofi_spin_lock(&srx->lock);
-	dlist_entry = dlist_remove_first_match(&srx->unexp_msg_queue.list,
-					       srx->unexp_msg_queue.match_func,
-					       &match_attr);
-	if (!dlist_entry) {
-		rx_entry = smr_get_recv_entry(srx, iov, desc, iov_count, addr,
-					      context, 0, 0, flags);
-		if (!rx_entry)
-			ret = -FI_ENOMEM;
-		else
-			dlist_insert_tail((struct dlist_entry *)
-					  (&rx_entry->peer_entry),
-					  &srx->recv_queue.list);
-		ofi_spin_unlock(&srx->lock);
-		return ret;
-	}
-	ofi_spin_unlock(&srx->lock);
-
-	rx_entry = container_of(dlist_entry, struct smr_rx_entry, peer_entry);
-	smr_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context,
-			  0, flags);
-
-	return rx_entry->peer_entry.srx->peer_ops->start_msg(
-						&rx_entry->peer_entry);
-}
-
 static ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-		    uint64_t flags)
+			   uint64_t flags)
 {
 	struct smr_ep *ep;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
-	return smr_generic_recv(smr_get_smr_srx(ep), msg->msg_iov, msg->desc,
-				msg->iov_count, msg->addr, msg->context,
-				flags | ep->util_ep.rx_msg_flags);
+	return util_srx_generic_recv(ep->srx, msg->msg_iov, msg->desc,
+				     msg->iov_count, msg->addr, msg->context,
+				     flags | ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -213,8 +58,8 @@ static ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
-	return smr_generic_recv(smr_get_smr_srx(ep), iov, desc, count, src_addr,
-				context, smr_ep_rx_flags(ep));
+	return util_srx_generic_recv(ep->srx, iov, desc, count, src_addr,
+				     context, smr_ep_rx_flags(ep));
 }
 
 static ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len,
@@ -228,46 +73,8 @@ static ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return smr_generic_recv(smr_get_smr_srx(ep), &iov, &desc, 1, src_addr,
-				context, smr_ep_rx_flags(ep));
-}
-
-static ssize_t smr_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-			       uint64_t flags)
-{
-	struct smr_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct smr_srx_ctx, peer_srx.ep_fid);
-
-	return smr_generic_recv(srx, msg->msg_iov, msg->desc, msg->iov_count,
-				msg->addr, msg->context,
-				flags | srx->rx_msg_flags);
-}
-
-static ssize_t smr_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-			     size_t count, fi_addr_t src_addr, void *context)
-{
-	struct smr_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct smr_srx_ctx, peer_srx.ep_fid);
-
-	return smr_generic_recv(srx, iov, desc, count, src_addr, context,
-				srx->rx_op_flags);
-}
-
-static ssize_t smr_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
-			    fi_addr_t src_addr, void *context)
-{
-	struct iovec iov;
-	struct smr_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct smr_srx_ctx, peer_srx.ep_fid);
-
-	iov.iov_base = buf;
-	iov.iov_len = len;
-
-	return smr_generic_recv(srx, &iov, &desc, 1, src_addr, context,
-				srx->rx_op_flags);
+	return util_srx_generic_recv(ep->srx, &iov, &desc, 1, src_addr, context,
+				     smr_ep_rx_flags(ep));
 }
 
 static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
@@ -493,62 +300,6 @@ struct fi_ops_msg smr_no_recv_msg_ops = {
 	.injectdata = smr_injectdata,
 };
 
-struct fi_ops_msg smr_srx_msg_ops = {
-	.size = sizeof(struct fi_ops_tagged),
-	.recv = smr_srx_recv,
-	.recvv = smr_srx_recvv,
-	.recvmsg = smr_srx_recvmsg,
-	.send = fi_no_msg_send,
-	.sendv = fi_no_msg_sendv,
-	.sendmsg = fi_no_msg_sendmsg,
-	.inject = fi_no_msg_inject,
-	.senddata = fi_no_msg_senddata,
-	.injectdata = fi_no_msg_injectdata,
-};
-
-static ssize_t smr_generic_trecv(struct smr_srx_ctx *srx,
-		const struct iovec *iov, void **desc, size_t iov_count,
-		fi_addr_t addr, void *context, uint64_t tag, uint64_t ignore,
-		uint64_t flags)
-{
-	struct smr_match_attr match_attr;
-	struct smr_rx_entry *rx_entry;
-	struct dlist_entry *dlist_entry;
-	int ret = FI_SUCCESS;
-
-	assert(iov_count <= SMR_IOV_LIMIT);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-	match_attr.ignore = ignore;
-	match_attr.tag = tag;
-
-	ofi_spin_lock(&srx->lock);
-	dlist_entry = dlist_remove_first_match(&srx->unexp_tagged_queue.list,
-					srx->unexp_tagged_queue.match_func,
-					&match_attr);
-	if (!dlist_entry) {
-		rx_entry = smr_get_recv_entry(srx, iov, desc, iov_count, addr,
-					      context, tag, ignore, flags);
-		if (!rx_entry)
-			ret = -FI_ENOMEM;
-		else
-			dlist_insert_tail((struct dlist_entry *)
-					  (&rx_entry->peer_entry),
-					  &srx->trecv_queue.list);
-		ofi_spin_unlock(&srx->lock);
-		return ret;
-	}
-	ofi_spin_unlock(&srx->lock);
-
-	rx_entry = container_of(dlist_entry, struct smr_rx_entry, peer_entry);
-	smr_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context,
-			  tag, flags);
-
-	return rx_entry->peer_entry.srx->peer_ops->start_tag(
-						&rx_entry->peer_entry);
-}
-
 static ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 			 void *desc, fi_addr_t src_addr, uint64_t tag,
 			 uint64_t ignore, void *context)
@@ -561,8 +312,8 @@ static ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return smr_generic_trecv(smr_get_smr_srx(ep), &iov, &desc, 1, src_addr,
-				 context, tag, ignore, smr_ep_rx_flags(ep));
+	return util_srx_generic_trecv(ep->srx, &iov, &desc, 1, src_addr, context,
+				     tag, ignore, smr_ep_rx_flags(ep));
 }
 
 static ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -573,8 +324,8 @@ static ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
-	return smr_generic_trecv(smr_get_smr_srx(ep), iov, desc, count, src_addr,
-				 context, tag, ignore, smr_ep_rx_flags(ep));
+	return util_srx_generic_trecv(ep->srx, iov, desc, count, src_addr,
+				     context, tag, ignore, smr_ep_rx_flags(ep));
 }
 
 static ssize_t smr_trecvmsg(struct fid_ep *ep_fid,
@@ -584,49 +335,10 @@ static ssize_t smr_trecvmsg(struct fid_ep *ep_fid,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
-	return smr_generic_trecv(smr_get_smr_srx(ep), msg->msg_iov, msg->desc,
-				 msg->iov_count, msg->addr, msg->context,
-				 msg->tag, msg->ignore,
-				 flags | ep->util_ep.rx_msg_flags);
-}
-
-static ssize_t smr_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
-	fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context)
-{
-	struct iovec iov;
-	struct smr_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct smr_srx_ctx, peer_srx.ep_fid);
-
-	iov.iov_base = buf;
-	iov.iov_len = len;
-
-	return smr_generic_trecv(srx, &iov, &desc, 1, src_addr, context, tag,
-				 ignore, srx->rx_op_flags);
-}
-
-static ssize_t smr_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-	size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
-	void *context)
-{
-	struct smr_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct smr_srx_ctx, peer_srx.ep_fid);
-
-	return smr_generic_trecv(srx, iov, desc, count, src_addr, context, tag,
-				 ignore, srx->rx_op_flags);
-}
-
-static ssize_t smr_srx_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
-	uint64_t flags)
-{
-	struct smr_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct smr_srx_ctx, peer_srx.ep_fid);
-
-	return smr_generic_trecv(srx, msg->msg_iov, msg->desc, msg->iov_count,
-				msg->addr, msg->context, msg->tag, msg->ignore,
-				flags | srx->rx_msg_flags);
+	return util_srx_generic_trecv(ep->srx, msg->msg_iov, msg->desc,
+				     msg->iov_count, msg->addr, msg->context,
+				     msg->tag, msg->ignore,
+				     flags | ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t smr_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -723,19 +435,6 @@ struct fi_ops_tagged smr_no_recv_tag_ops = {
 	.recvmsg = fi_no_tagged_recvmsg,
 	.send = smr_tsend,
 	.sendv = smr_tsendv,
-	.sendmsg = smr_tsendmsg,
-	.inject = smr_tinject,
-	.senddata = smr_tsenddata,
-	.injectdata = smr_tinjectdata,
-};
-
-struct fi_ops_tagged smr_srx_tag_ops = {
-	.size = sizeof(struct fi_ops_tagged),
-	.recv = smr_srx_trecv,
-	.recvv = smr_srx_trecvv,
-	.recvmsg = smr_srx_trecvmsg,
-	.send = fi_no_tagged_send,
-	.sendv = fi_no_tagged_sendv,
 	.sendmsg = smr_tsendmsg,
 	.inject = smr_tinject,
 	.senddata = smr_tsenddata,

--- a/prov/sm2/src/sm2.h
+++ b/prov/sm2/src/sm2.h
@@ -157,18 +157,6 @@ int sm2_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 int sm2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		struct fid_av **av, void *context);
 
-static inline int sm2_match_id(fi_addr_t addr, fi_addr_t match_addr)
-{
-	return (addr == FI_ADDR_UNSPEC) || (match_addr == FI_ADDR_UNSPEC) ||
-	       (addr == match_addr);
-}
-
-static inline int sm2_match_tag(uint64_t tag, uint64_t ignore,
-				uint64_t match_tag)
-{
-	return ((tag | ignore) == (match_tag | ignore));
-}
-
 static inline void sm2_generic_format(struct sm2_xfer_entry *xfer_entry,
 				      sm2_gid_t self_gid, uint32_t op,
 				      uint64_t tag, uint64_t cq_data,
@@ -194,49 +182,6 @@ struct sm2_domain {
 	struct fid_peer_srx *srx;
 };
 
-struct sm2_rx_entry {
-	struct fi_peer_rx_entry peer_entry;
-	struct iovec iov[SM2_IOV_LIMIT];
-	void *desc[SM2_IOV_LIMIT];
-	int64_t peer_id;
-	uint64_t ignore;
-	int multi_recv_ref;
-	uint64_t err;
-};
-
-struct sm2_queue {
-	struct dlist_entry list;
-	dlist_func_t *match_func;
-};
-
-OFI_DECLARE_FREESTACK(struct sm2_rx_entry, sm2_recv_fs);
-
-struct sm2_match_attr {
-	fi_addr_t id;
-	uint64_t tag;
-	uint64_t ignore;
-};
-
-struct sm2_srx_ctx {
-	struct fid_peer_srx peer_srx;
-	struct sm2_queue recv_queue;
-	struct sm2_queue trecv_queue;
-	bool dir_recv;
-	size_t min_multi_recv_size;
-	uint64_t rx_op_flags;
-	uint64_t rx_msg_flags;
-
-	struct util_cq *cq;
-	struct sm2_queue unexp_msg_queue;
-	struct sm2_queue unexp_tagged_queue;
-	struct sm2_recv_fs *recv_fs;
-
-	// TODO Determine if this spin lock is needed.
-	ofi_spin_t lock;
-};
-
-struct sm2_rx_entry *sm2_alloc_rx_entry(struct sm2_srx_ctx *srx);
-
 struct sm2_ep {
 	struct util_ep util_ep;
 	size_t rx_size;
@@ -248,11 +193,6 @@ struct sm2_ep {
 	struct ofi_bufpool *xfer_ctx_pool;
 	int ep_idx;
 };
-
-static inline struct sm2_srx_ctx *sm2_get_srx(struct sm2_ep *ep)
-{
-	return (struct sm2_srx_ctx *) ep->srx->fid.context;
-}
 
 static inline struct fid_peer_srx *sm2_get_peer_srx(struct sm2_ep *ep)
 {
@@ -314,17 +254,6 @@ static inline struct sm2_region *sm2_peer_region(struct sm2_ep *ep, int id)
 	return sm2_mmap_ep_region(&av->mmap, id);
 }
 
-bool sm2_adjust_multi_recv(struct sm2_srx_ctx *srx,
-			   struct fi_peer_rx_entry *rx_entry, size_t len);
-void sm2_init_rx_entry(struct sm2_rx_entry *entry, const struct iovec *iov,
-		       void **desc, size_t count, fi_addr_t addr, void *context,
-		       uint64_t tag, uint64_t flags);
-struct sm2_rx_entry *sm2_get_recv_entry(struct sm2_srx_ctx *srx,
-					const struct iovec *iov, void **desc,
-					size_t count, fi_addr_t addr,
-					void *context, uint64_t tag,
-					uint64_t ignore, uint64_t flags);
-
 static inline size_t sm2_pop_xfer_entry(struct sm2_ep *ep,
 					struct sm2_xfer_entry **xfer_entry)
 {
@@ -342,5 +271,4 @@ static inline size_t sm2_pop_xfer_entry(struct sm2_ep *ep,
 	*xfer_entry = smr_freestack_pop(sm2_freestack(self_region));
 	return FI_SUCCESS;
 }
-
 #endif /* _SM2_H_ */

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -44,8 +44,8 @@
 #include "sm2_fifo.h"
 
 pthread_mutex_t sm2_ep_list_lock = PTHREAD_MUTEX_INITIALIZER;
-extern struct fi_ops_msg sm2_msg_ops, sm2_no_recv_msg_ops, sm2_srx_msg_ops;
-extern struct fi_ops_tagged sm2_tag_ops, sm2_no_recv_tag_ops, sm2_srx_tag_ops;
+extern struct fi_ops_msg sm2_msg_ops, sm2_no_recv_msg_ops;
+extern struct fi_ops_tagged sm2_tag_ops, sm2_no_recv_tag_ops;
 int sm2_global_ep_idx = 0;
 
 int sm2_setname(fid_t fid, void *addr, size_t addrlen)
@@ -104,121 +104,60 @@ static struct fi_ops_cm sm2_cm_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
-int sm2_getopt(fid_t fid, int level, int optname, void *optval, size_t *optlen)
+static int sm2_ep_getopt(fid_t fid, int level, int optname, void *optval,
+			 size_t *optlen)
 {
-	struct sm2_ep *sm2_ep =
-		container_of(fid, struct sm2_ep, util_ep.ep_fid);
+	struct sm2_ep *ep = container_of(fid, struct sm2_ep, util_ep.ep_fid);
+	return ep->srx->ops->getopt(&ep->srx->fid, level, optname, optval,
+				    optlen);
+}
 
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
+static int sm2_ep_setopt(fid_t fid, int level, int optname, const void *optval,
+			 size_t optlen)
+{
+	struct sm2_ep *ep = container_of(fid, struct sm2_ep, util_ep.ep_fid);
+	struct util_srx_ctx *srx =
+		util_get_peer_srx(ep->srx)->ep_fid.fid.context;
+
+	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
-	*(size_t *) optval = sm2_get_srx(sm2_ep)->min_multi_recv_size;
-	*optlen = sizeof(size_t);
-
-	return FI_SUCCESS;
-}
-
-int sm2_setopt(fid_t fid, int level, int optname, const void *optval,
-	       size_t optlen)
-{
-	struct sm2_ep *sm2_ep =
-		container_of(fid, struct sm2_ep, util_ep.ep_fid);
-
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
-		return -FI_ENOPROTOOPT;
-
-	sm2_get_srx(sm2_ep)->min_multi_recv_size = *(size_t *) optval;
-
-	return FI_SUCCESS;
-}
-
-static int sm2_match_recv_ctx(struct dlist_entry *item, const void *args)
-{
-	struct sm2_rx_entry *pending_recv;
-
-	pending_recv = container_of(item, struct sm2_rx_entry, peer_entry);
-	return pending_recv->peer_entry.context == args;
-}
-
-static int sm2_ep_cancel_recv(struct sm2_ep *ep, struct sm2_queue *queue,
-			      void *context, uint32_t op)
-{
-	struct sm2_srx_ctx *srx = sm2_get_srx(ep);
-	struct sm2_rx_entry *recv_entry;
-	struct dlist_entry *entry;
-	int ret = 0;
-
-	ofi_spin_lock(&srx->lock);
-	entry = dlist_remove_first_match(&queue->list, sm2_match_recv_ctx,
-					 context);
-	if (entry) {
-		recv_entry =
-			container_of(entry, struct sm2_rx_entry, peer_entry);
-		ret = sm2_write_err_comp(
-			ep->util_ep.rx_cq, recv_entry->peer_entry.context,
-			sm2_rx_cq_flags(op, recv_entry->peer_entry.flags, 0),
-			recv_entry->peer_entry.tag, FI_ECANCELED);
-		ofi_freestack_push(srx->recv_fs, recv_entry);
-		ret = ret ? ret : 1;
+	if (optname == FI_OPT_MIN_MULTI_RECV) {
+		srx->min_multi_recv_size = *(size_t *) optval;
+		return FI_SUCCESS;
 	}
 
-	ofi_spin_unlock(&srx->lock);
-	return ret;
+	if (optname == FI_OPT_CUDA_API_PERMITTED) {
+		if (!hmem_ops[FI_HMEM_CUDA].initialized) {
+			FI_WARN(&sm2_prov, FI_LOG_CORE,
+				"Cannot set option FI_OPT_CUDA_API_PERMITTED "
+				"when cuda library or cuda device not "
+				"available\n");
+			return -FI_EINVAL;
+		}
+		/* our CUDA support relies on the ability to call CUDA API */
+		return *(bool *) optval ? FI_SUCCESS : -FI_EOPNOTSUPP;
+	}
+	return -FI_ENOPROTOOPT;
 }
 
 static ssize_t sm2_ep_cancel(fid_t ep_fid, void *context)
 {
 	struct sm2_ep *ep;
-	int ret;
-
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid);
-
-	ret = sm2_ep_cancel_recv(ep, &sm2_get_srx(ep)->trecv_queue, context,
-				 ofi_op_tagged);
-	if (ret)
-		return (ret < 0) ? ret : 0;
-
-	ret = sm2_ep_cancel_recv(ep, &sm2_get_srx(ep)->recv_queue, context,
-				 ofi_op_msg);
-	return (ret < 0) ? ret : 0;
+	return ep->srx->ops->cancel(&ep->srx->fid, context);
 }
 
 static struct fi_ops_ep sm2_ep_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = sm2_ep_cancel,
-	.getopt = sm2_getopt,
-	.setopt = sm2_setopt,
+	.getopt = sm2_ep_getopt,
+	.setopt = sm2_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,
 	.tx_size_left = fi_no_tx_size_left,
 };
-
-static int sm2_match_msg(struct dlist_entry *item, const void *args)
-{
-	struct sm2_match_attr *attr = (struct sm2_match_attr *) args;
-	struct sm2_rx_entry *recv_entry;
-
-	recv_entry = container_of(item, struct sm2_rx_entry, peer_entry);
-	return sm2_match_id(recv_entry->peer_entry.addr, attr->id);
-}
-
-static int sm2_match_tagged(struct dlist_entry *item, const void *args)
-{
-	struct sm2_match_attr *attr = (struct sm2_match_attr *) args;
-	struct sm2_rx_entry *recv_entry;
-
-	recv_entry = container_of(item, struct sm2_rx_entry, peer_entry);
-	return sm2_match_id(recv_entry->peer_entry.addr, attr->id) &&
-	       sm2_match_tag(recv_entry->peer_entry.tag, recv_entry->ignore,
-			     attr->tag);
-}
-
-static void sm2_init_queue(struct sm2_queue *queue, dlist_func_t *match_func)
-{
-	dlist_init(&queue->list);
-	queue->match_func = match_func;
-}
 
 ssize_t sm2_verify_peer(struct sm2_ep *ep, fi_addr_t fi_addr, sm2_gid_t *gid)
 {
@@ -270,81 +209,6 @@ static ssize_t sm2_do_inject(struct sm2_ep *ep, struct sm2_region *peer_smr,
 	sm2_format_inject(xfer_entry, mr, iov, iov_count);
 
 	sm2_fifo_write(ep, peer_gid, xfer_entry);
-	return FI_SUCCESS;
-}
-
-int sm2_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
-{
-	struct sm2_srx_ctx *srx;
-
-	if (flags != FI_RECV || bfid->fclass != FI_CLASS_CQ)
-		return -FI_EINVAL;
-
-	srx = container_of(fid, struct sm2_srx_ctx, peer_srx.ep_fid.fid);
-	srx->cq = container_of(bfid, struct util_cq, cq_fid.fid);
-	ofi_atomic_inc32(&srx->cq->ref);
-	return FI_SUCCESS;
-}
-
-static void sm2_close_recv_queue(struct sm2_srx_ctx *srx,
-				 struct sm2_queue *recv_queue)
-{
-	struct fi_cq_err_entry err_entry;
-	struct sm2_rx_entry *rx_entry;
-	int ret;
-
-	while (!dlist_empty(&recv_queue->list)) {
-		dlist_pop_front(&recv_queue->list, struct sm2_rx_entry,
-				rx_entry, peer_entry);
-
-		memset(&err_entry, 0, sizeof err_entry);
-		err_entry.op_context = rx_entry->peer_entry.context;
-		err_entry.flags = rx_entry->peer_entry.flags;
-		err_entry.tag = rx_entry->peer_entry.tag;
-		err_entry.err = FI_ECANCELED;
-		err_entry.prov_errno = -FI_ECANCELED;
-		ret = srx->cq->peer_cq->owner_ops->writeerr(srx->cq->peer_cq,
-							    &err_entry);
-		if (ret)
-			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-				"Error writing recv entry error to rx cq\n");
-
-		ofi_freestack_push(srx->recv_fs, rx_entry);
-	}
-}
-
-static void sm2_close_unexp_queue(struct sm2_srx_ctx *srx,
-				  struct sm2_queue *unexp_queue)
-{
-	struct sm2_rx_entry *rx_entry;
-
-	while (!dlist_empty(&unexp_queue->list)) {
-		dlist_pop_front(&unexp_queue->list, struct sm2_rx_entry,
-				rx_entry, peer_entry);
-		rx_entry->peer_entry.srx->peer_ops->discard_msg(
-			&rx_entry->peer_entry);
-	}
-}
-
-static int sm2_srx_close(struct fid *fid)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(fid, struct sm2_srx_ctx, peer_srx.ep_fid.fid);
-	if (!srx)
-		return -FI_EINVAL;
-
-	sm2_close_recv_queue(srx, &srx->recv_queue);
-	sm2_close_recv_queue(srx, &srx->trecv_queue);
-
-	sm2_close_unexp_queue(srx, &srx->unexp_msg_queue);
-	sm2_close_unexp_queue(srx, &srx->unexp_tagged_queue);
-
-	ofi_atomic_dec32(&srx->cq->ref);
-	sm2_recv_fs_free(srx->recv_fs);
-	ofi_spin_destroy(&srx->lock);
-	free(srx);
-
 	return FI_SUCCESS;
 }
 
@@ -419,7 +283,7 @@ static int sm2_ep_close(struct fid *fid)
 	}
 
 	if (ep->util_ep.ep_fid.msg != &sm2_no_recv_msg_ops)
-		sm2_srx_close(&ep->srx->fid);
+		(void) util_srx_close(&ep->srx->fid);
 
 	if (ep->xfer_ctx_pool)
 		ofi_bufpool_destroy(ep->xfer_ctx_pool);
@@ -522,192 +386,6 @@ static int sm2_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 	return ret;
 }
 
-bool sm2_adjust_multi_recv(struct sm2_srx_ctx *srx,
-			   struct fi_peer_rx_entry *rx_entry, size_t len)
-{
-	size_t left;
-	void *new_base;
-
-	left = rx_entry->iov[0].iov_len - len;
-
-	new_base = (void *) ((uintptr_t) rx_entry->iov[0].iov_base + len);
-	rx_entry->iov[0].iov_len = left;
-	rx_entry->iov[0].iov_base = new_base;
-	rx_entry->size = left;
-
-	return left < srx->min_multi_recv_size;
-}
-
-static int sm2_get_msg(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
-		       struct fi_peer_rx_entry **rx_entry)
-{
-	struct sm2_rx_entry *sm2_entry;
-	struct sm2_srx_ctx *srx_ctx;
-	struct sm2_match_attr match_attr;
-	struct dlist_entry *dlist_entry;
-	struct sm2_rx_entry *owner_entry;
-	int ret;
-
-	srx_ctx = srx->ep_fid.fid.context;
-	ofi_spin_lock(&srx_ctx->lock);
-
-	match_attr.id = addr;
-
-	dlist_entry = dlist_find_first_match(&srx_ctx->recv_queue.list,
-					     srx_ctx->recv_queue.match_func,
-					     &match_attr);
-	if (!dlist_entry) {
-		sm2_entry = sm2_alloc_rx_entry(srx_ctx);
-		if (!sm2_entry) {
-			ret = -FI_ENOMEM;
-		} else {
-			sm2_entry->peer_entry.owner_context = NULL;
-			sm2_entry->peer_entry.addr = addr;
-			sm2_entry->peer_entry.size = size;
-			sm2_entry->peer_entry.srx = srx;
-			*rx_entry = &sm2_entry->peer_entry;
-			ret = -FI_ENOENT;
-		}
-		goto out;
-	}
-
-	*rx_entry = (struct fi_peer_rx_entry *) dlist_entry;
-
-	if ((*rx_entry)->flags & FI_MULTI_RECV) {
-		owner_entry = container_of(*rx_entry, struct sm2_rx_entry,
-					   peer_entry);
-		sm2_entry = sm2_get_recv_entry(
-			srx_ctx, owner_entry->iov, owner_entry->desc,
-			owner_entry->peer_entry.count, addr,
-			owner_entry->peer_entry.context,
-			owner_entry->peer_entry.tag, owner_entry->ignore,
-			owner_entry->peer_entry.flags & (~FI_MULTI_RECV));
-		if (!sm2_entry) {
-			ret = -FI_ENOMEM;
-			goto out;
-		}
-
-		if (sm2_adjust_multi_recv(srx_ctx, &owner_entry->peer_entry,
-					  size))
-			dlist_remove(dlist_entry);
-
-		sm2_entry->peer_entry.owner_context = owner_entry;
-		*rx_entry = &sm2_entry->peer_entry;
-		owner_entry->multi_recv_ref++;
-	} else {
-		dlist_remove(dlist_entry);
-	}
-
-	(*rx_entry)->srx = srx;
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx_ctx->lock);
-	return ret;
-}
-
-static int sm2_get_tag(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
-		       uint64_t tag, struct fi_peer_rx_entry **rx_entry)
-{
-	struct sm2_rx_entry *sm2_entry;
-	struct sm2_srx_ctx *srx_ctx;
-	struct sm2_match_attr match_attr;
-	struct dlist_entry *dlist_entry;
-	int ret;
-
-	srx_ctx = srx->ep_fid.fid.context;
-	ofi_spin_lock(&srx_ctx->lock);
-
-	match_attr.id = addr;
-	match_attr.tag = tag;
-
-	dlist_entry = dlist_find_first_match(&srx_ctx->trecv_queue.list,
-					     srx_ctx->trecv_queue.match_func,
-					     &match_attr);
-	if (!dlist_entry) {
-		sm2_entry = sm2_alloc_rx_entry(srx_ctx);
-		if (!sm2_entry) {
-			ret = -FI_ENOMEM;
-		} else {
-			sm2_entry->peer_entry.owner_context = NULL;
-			sm2_entry->peer_entry.addr = addr;
-			sm2_entry->peer_entry.size = size;
-			sm2_entry->peer_entry.tag = tag;
-			sm2_entry->peer_entry.srx = srx;
-			*rx_entry = &sm2_entry->peer_entry;
-			ret = -FI_ENOENT;
-		}
-		goto out;
-	}
-	dlist_remove(dlist_entry);
-
-	*rx_entry = (struct fi_peer_rx_entry *) dlist_entry;
-	(*rx_entry)->srx = srx;
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx_ctx->lock);
-	return ret;
-}
-
-static int sm2_queue_msg(struct fi_peer_rx_entry *rx_entry)
-{
-	struct sm2_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
-
-	ofi_spin_lock(&srx_ctx->lock);
-	dlist_insert_tail((struct dlist_entry *) rx_entry,
-			  &srx_ctx->unexp_msg_queue.list);
-	ofi_spin_unlock(&srx_ctx->lock);
-	return 0;
-}
-
-static int sm2_queue_tag(struct fi_peer_rx_entry *rx_entry)
-{
-	struct sm2_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
-
-	ofi_spin_lock(&srx_ctx->lock);
-	dlist_insert_tail((struct dlist_entry *) rx_entry,
-			  &srx_ctx->unexp_tagged_queue.list);
-	ofi_spin_unlock(&srx_ctx->lock);
-	return 0;
-}
-
-static void sm2_free_entry(struct fi_peer_rx_entry *entry)
-{
-	struct sm2_srx_ctx *srx =
-		(struct sm2_srx_ctx *) entry->srx->ep_fid.fid.context;
-	struct sm2_rx_entry *sm2_entry, *owner_entry;
-
-	ofi_spin_lock(&srx->lock);
-	sm2_entry = container_of(entry, struct sm2_rx_entry, peer_entry);
-	if (entry->owner_context) {
-		owner_entry = container_of(entry->owner_context,
-					   struct sm2_rx_entry, peer_entry);
-		if (!--owner_entry->multi_recv_ref &&
-		    owner_entry->peer_entry.size < srx->min_multi_recv_size) {
-			if (ofi_peer_cq_write(srx->cq,
-					      owner_entry->peer_entry.context,
-					      FI_MULTI_RECV, 0, NULL, 0, 0,
-					      FI_ADDR_NOTAVAIL)) {
-				FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-					"unable to write rx MULTI_RECV "
-					"completion\n");
-			}
-			ofi_freestack_push(srx->recv_fs, owner_entry);
-		}
-	}
-
-	ofi_freestack_push(srx->recv_fs, sm2_entry);
-	ofi_spin_unlock(&srx->lock);
-}
-
-static struct fi_ops_srx_owner sm2_srx_owner_ops = {
-	.size = sizeof(struct fi_ops_srx_owner),
-	.get_msg = sm2_get_msg,
-	.get_tag = sm2_get_tag,
-	.queue_msg = sm2_queue_msg,
-	.queue_tag = sm2_queue_tag,
-	.free_entry = sm2_free_entry,
-};
-
 static int sm2_discard(struct fi_peer_rx_entry *rx_entry)
 {
 	struct sm2_xfer_ctx *xfer_ctx = rx_entry->peer_context;
@@ -724,66 +402,10 @@ struct fi_ops_srx_peer sm2_srx_peer_ops = {
 	.discard_tag = sm2_discard,
 };
 
-static struct fi_ops sm2_srx_fid_ops = {
-	.size = sizeof(struct fi_ops),
-	.close = sm2_srx_close,
-	.bind = sm2_srx_bind,
-	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
-};
-
-static struct fi_ops_ep sm2_srx_ops = {
-	.size = sizeof(struct fi_ops_ep),
-	.cancel = sm2_ep_cancel,
-	.getopt = fi_no_getopt,
-	.setopt = fi_no_setopt,
-	.tx_ctx = fi_no_tx_ctx,
-	.rx_ctx = fi_no_rx_ctx,
-	.rx_size_left = fi_no_rx_size_left,
-	.tx_size_left = fi_no_tx_size_left,
-};
-
-static int sm2_ep_srx_context(struct sm2_domain *domain, size_t rx_size,
-			      struct fid_ep **rx_ep)
+static void sm2_update(struct util_srx_ctx *srx, struct util_rx_entry *rx_entry)
 {
-	struct sm2_srx_ctx *srx;
-	int ret = FI_SUCCESS;
-
-	srx = calloc(1, sizeof(*srx));
-	if (!srx)
-		return -FI_ENOMEM;
-
-	ret = ofi_spin_init(&srx->lock);
-	if (ret)
-		goto err;
-
-	sm2_init_queue(&srx->recv_queue, sm2_match_msg);
-	sm2_init_queue(&srx->trecv_queue, sm2_match_tagged);
-	sm2_init_queue(&srx->unexp_msg_queue, sm2_match_msg);
-	sm2_init_queue(&srx->unexp_tagged_queue, sm2_match_tagged);
-
-	srx->recv_fs = sm2_recv_fs_create(rx_size, NULL, NULL);
-
-	srx->min_multi_recv_size = SM2_INJECT_SIZE;
-	srx->dir_recv = domain->util_domain.info_domain_caps & FI_DIRECTED_RECV;
-
-	srx->peer_srx.owner_ops = &sm2_srx_owner_ops;
-	srx->peer_srx.peer_ops = &sm2_srx_peer_ops;
-
-	srx->peer_srx.ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
-	srx->peer_srx.ep_fid.fid.context = srx;
-	srx->peer_srx.ep_fid.fid.ops = &sm2_srx_fid_ops;
-	srx->peer_srx.ep_fid.ops = &sm2_srx_ops;
-
-	srx->peer_srx.ep_fid.msg = &sm2_srx_msg_ops;
-	srx->peer_srx.ep_fid.tagged = &sm2_srx_tag_ops;
-	*rx_ep = &srx->peer_srx.ep_fid;
-
-	return FI_SUCCESS;
-
-err:
-	free(srx);
-	return ret;
+	// no update needed - sm2 only used as the owner when not used as a peer
+	// by another provider
 }
 
 int sm2_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
@@ -800,7 +422,10 @@ int sm2_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		sm2_domain->srx->peer_ops = &sm2_srx_peer_ops;
 		return FI_SUCCESS;
 	}
-	return sm2_ep_srx_context(sm2_domain, attr->size, rx_ep);
+
+	return util_ep_srx_context(&sm2_domain->util_domain, attr->size,
+				   SM2_IOV_LIMIT, SM2_INJECT_SIZE, &sm2_update,
+				   rx_ep);
 }
 
 static int sm2_ep_ctrl(struct fid *fid, int command, void *arg)
@@ -809,6 +434,7 @@ static int sm2_ep_ctrl(struct fid *fid, int command, void *arg)
 	struct sm2_domain *domain;
 	struct sm2_ep *ep;
 	struct sm2_av *av;
+	struct fid_peer_srx *srx;
 	int ret;
 	sm2_gid_t self_gid;
 
@@ -836,15 +462,27 @@ static int sm2_ep_ctrl(struct fid *fid, int command, void *arg)
 			domain = container_of(ep->util_ep.domain,
 					      struct sm2_domain,
 					      util_domain.domain_fid);
-			ret = sm2_ep_srx_context(domain, ep->rx_size, &ep->srx);
+			ret = util_ep_srx_context(&domain->util_domain,
+						  ep->rx_size, SM2_IOV_LIMIT,
+						  SM2_INJECT_SIZE, &sm2_update,
+						  &ep->srx);
 			if (ret)
 				return ret;
-			ret = sm2_srx_bind(&ep->srx->fid,
-					   &ep->util_ep.rx_cq->cq_fid.fid,
-					   FI_RECV);
+
+			util_get_peer_srx(ep->srx)->peer_ops =
+				&sm2_srx_peer_ops;
+			ret = util_srx_bind(&ep->srx->fid,
+					    &ep->util_ep.rx_cq->cq_fid.fid,
+					    FI_RECV);
 			if (ret)
 				return ret;
 		} else {
+			srx = calloc(1, sizeof(*srx));
+			srx->peer_ops = &sm2_srx_peer_ops;
+			srx->owner_ops = sm2_get_peer_srx(ep)->owner_ops;
+			srx->ep_fid.fid.context =
+				sm2_get_peer_srx(ep)->ep_fid.fid.context;
+			ep->srx = &srx->ep_fid;
 			ep->util_ep.ep_fid.msg = &sm2_no_recv_msg_ops;
 			ep->util_ep.ep_fid.tagged = &sm2_no_recv_tag_ops;
 		}

--- a/prov/sm2/src/sm2_msg.c
+++ b/prov/sm2/src/sm2_msg.c
@@ -38,166 +38,6 @@
 #include "ofi_iov.h"
 #include "sm2.h"
 
-struct sm2_rx_entry *sm2_alloc_rx_entry(struct sm2_srx_ctx *srx)
-{
-	if (ofi_freestack_isempty(srx->recv_fs)) {
-		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
-			"not enough space to post recv\n");
-		return NULL;
-	}
-
-	return ofi_freestack_pop(srx->recv_fs);
-}
-
-void sm2_init_rx_entry(struct sm2_rx_entry *entry, const struct iovec *iov,
-		       void **desc, size_t count, fi_addr_t addr, void *context,
-		       uint64_t tag, uint64_t flags)
-{
-	memcpy(&entry->iov, iov, sizeof(*iov) * count);
-	if (desc)
-		memcpy(entry->desc, desc, sizeof(*desc) * count);
-
-	entry->peer_entry.iov = entry->iov;
-	entry->peer_entry.desc = entry->desc;
-	entry->peer_entry.count = count;
-	entry->peer_entry.addr = addr;
-	entry->peer_entry.context = context;
-	entry->peer_entry.tag = tag;
-	entry->peer_entry.flags = flags;
-}
-
-struct sm2_rx_entry *sm2_get_recv_entry(struct sm2_srx_ctx *srx,
-					const struct iovec *iov, void **desc,
-					size_t count, fi_addr_t addr,
-					void *context, uint64_t tag,
-					uint64_t ignore, uint64_t flags)
-{
-	struct sm2_rx_entry *entry;
-
-	entry = sm2_alloc_rx_entry(srx);
-	if (!entry)
-		return NULL;
-
-	sm2_init_rx_entry(entry, iov, desc, count, addr, context, tag, flags);
-
-	entry->peer_entry.owner_context = NULL;
-
-	entry->multi_recv_ref = 0;
-	entry->ignore = ignore;
-	entry->err = 0;
-
-	return entry;
-}
-
-static ssize_t sm2_generic_mrecv(struct sm2_srx_ctx *srx,
-				 const struct iovec *iov, void **desc,
-				 size_t iov_count, fi_addr_t addr,
-				 void *context, uint64_t flags)
-{
-	struct sm2_match_attr match_attr;
-	struct sm2_rx_entry *rx_entry, *mrecv_entry;
-	struct dlist_entry *dlist_entry;
-	bool buf_done = false;
-	int ret;
-
-	assert(flags & FI_MULTI_RECV && iov_count == 1);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-
-	ofi_spin_lock(&srx->lock);
-	mrecv_entry = sm2_get_recv_entry(srx, iov, desc, iov_count, addr,
-					 context, 0, 0, flags);
-	if (!mrecv_entry) {
-		ret = -FI_ENOMEM;
-		goto out;
-	}
-	mrecv_entry->peer_entry.size = ofi_total_iov_len(iov, iov_count);
-
-	dlist_entry = dlist_remove_first_match(&srx->unexp_msg_queue.list,
-					       srx->unexp_msg_queue.match_func,
-					       &match_attr);
-	while (dlist_entry) {
-		rx_entry = container_of(dlist_entry, struct sm2_rx_entry,
-					peer_entry);
-		sm2_init_rx_entry(rx_entry, mrecv_entry->peer_entry.iov, desc,
-				  iov_count, addr, context, 0,
-				  flags & (~FI_MULTI_RECV));
-		mrecv_entry->multi_recv_ref++;
-		rx_entry->peer_entry.owner_context = mrecv_entry;
-
-		if (sm2_adjust_multi_recv(srx, &mrecv_entry->peer_entry,
-					  rx_entry->peer_entry.size))
-			buf_done = true;
-
-		ofi_spin_unlock(&srx->lock);
-		ret = srx->peer_srx.peer_ops->start_msg(&rx_entry->peer_entry);
-		if (ret || buf_done)
-			return ret;
-
-		ofi_spin_lock(&srx->lock);
-		dlist_entry = dlist_remove_first_match(
-			&srx->unexp_msg_queue.list,
-			srx->unexp_msg_queue.match_func, &match_attr);
-	}
-
-	dlist_insert_tail((struct dlist_entry *) (&mrecv_entry->peer_entry),
-			  &srx->recv_queue.list);
-	ret = FI_SUCCESS;
-out:
-	ofi_spin_unlock(&srx->lock);
-	return ret;
-}
-
-static ssize_t sm2_generic_recv(struct sm2_srx_ctx *srx,
-				const struct iovec *iov, void **desc,
-				size_t iov_count, fi_addr_t addr, void *context,
-				uint64_t tag, uint64_t ignore, uint64_t flags,
-				struct sm2_queue *recv_queue,
-				struct sm2_queue *unexp_queue)
-{
-	struct sm2_match_attr match_attr;
-	struct sm2_rx_entry *rx_entry;
-	struct dlist_entry *dlist_entry;
-	int ret = FI_SUCCESS;
-
-	if (flags & FI_MULTI_RECV) {
-		assert(recv_queue != &srx->trecv_queue);
-		return sm2_generic_mrecv(srx, iov, desc, iov_count, addr,
-					 context, flags);
-	}
-
-	assert(iov_count <= SM2_IOV_LIMIT);
-
-	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
-	match_attr.id = addr;
-	match_attr.ignore = ignore;
-	match_attr.tag = tag;
-
-	ofi_spin_lock(&srx->lock);
-	dlist_entry = dlist_remove_first_match(
-		&unexp_queue->list, unexp_queue->match_func, &match_attr);
-	if (!dlist_entry) {
-		rx_entry = sm2_get_recv_entry(srx, iov, desc, iov_count, addr,
-					      context, tag, ignore, flags);
-		if (!rx_entry)
-			ret = -FI_ENOMEM;
-		else
-			dlist_insert_tail(
-				(struct dlist_entry *) (&rx_entry->peer_entry),
-				&recv_queue->list);
-		ofi_spin_unlock(&srx->lock);
-		return ret;
-	}
-	ofi_spin_unlock(&srx->lock);
-
-	rx_entry = container_of(dlist_entry, struct sm2_rx_entry, peer_entry);
-	sm2_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context, tag,
-			  flags);
-
-	return srx->peer_srx.peer_ops->start_msg(&rx_entry->peer_entry);
-}
-
 static ssize_t sm2_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			   uint64_t flags)
 {
@@ -205,11 +45,9 @@ static ssize_t sm2_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(sm2_get_srx(ep), msg->msg_iov, msg->desc,
-				msg->iov_count, msg->addr, msg->context, 0, 0,
-				flags | ep->util_ep.rx_msg_flags,
-				&sm2_get_srx(ep)->recv_queue,
-				&sm2_get_srx(ep)->unexp_msg_queue);
+	return util_srx_generic_recv(ep->srx, msg->msg_iov, msg->desc,
+				     msg->iov_count, msg->addr, msg->context,
+				     flags | ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t sm2_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -220,10 +58,8 @@ static ssize_t sm2_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(sm2_get_srx(ep), iov, desc, count, src_addr,
-				context, 0, 0, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->recv_queue,
-				&sm2_get_srx(ep)->unexp_msg_queue);
+	return util_srx_generic_recv(ep->srx, iov, desc, count, src_addr,
+				     context, sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_recv(struct fid_ep *ep_fid, void *buf, size_t len,
@@ -237,52 +73,8 @@ static ssize_t sm2_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return sm2_generic_recv(sm2_get_srx(ep), &iov, &desc, 1, src_addr,
-				context, 0, 0, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->recv_queue,
-				&sm2_get_srx(ep)->unexp_msg_queue);
-}
-
-static ssize_t sm2_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-			       uint64_t flags)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, msg->msg_iov, msg->desc, msg->iov_count,
-				msg->addr, msg->context, 0, 0,
-				flags | srx->rx_msg_flags, &srx->recv_queue,
-				&srx->unexp_msg_queue);
-}
-
-static ssize_t sm2_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
-			     void **desc, size_t count, fi_addr_t src_addr,
-			     void *context)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, iov, desc, count, src_addr, context, 0, 0,
-				srx->rx_op_flags, &srx->recv_queue,
-				&srx->unexp_msg_queue);
-}
-
-static ssize_t sm2_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
-			    void *desc, fi_addr_t src_addr, void *context)
-{
-	struct iovec iov;
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	iov.iov_base = buf;
-	iov.iov_len = len;
-
-	return sm2_generic_recv(srx, &iov, &desc, 1, src_addr, context, 0, 0,
-				srx->rx_op_flags, &srx->recv_queue,
-				&srx->unexp_msg_queue);
+	return util_srx_generic_recv(ep->srx, &iov, &desc, 1, src_addr, context,
+				     sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_generic_sendmsg(struct sm2_ep *ep, const struct iovec *iov,
@@ -460,19 +252,6 @@ struct fi_ops_msg sm2_no_recv_msg_ops = {
 	.injectdata = sm2_injectdata,
 };
 
-struct fi_ops_msg sm2_srx_msg_ops = {
-	.size = sizeof(struct fi_ops_tagged),
-	.recv = sm2_srx_recv,
-	.recvv = sm2_srx_recvv,
-	.recvmsg = sm2_srx_recvmsg,
-	.send = fi_no_msg_send,
-	.sendv = fi_no_msg_sendv,
-	.sendmsg = fi_no_msg_sendmsg,
-	.inject = fi_no_msg_inject,
-	.senddata = fi_no_msg_senddata,
-	.injectdata = fi_no_msg_injectdata,
-};
-
 static ssize_t sm2_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 			 void *desc, fi_addr_t src_addr, uint64_t tag,
 			 uint64_t ignore, void *context)
@@ -485,10 +264,9 @@ static ssize_t sm2_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 	iov.iov_base = buf;
 	iov.iov_len = len;
 
-	return sm2_generic_recv(sm2_get_srx(ep), &iov, &desc, 1, src_addr,
-				context, tag, ignore, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->trecv_queue,
-				&sm2_get_srx(ep)->unexp_tagged_queue);
+	return util_srx_generic_trecv(ep->srx, &iov, &desc, 1, src_addr,
+				      context, tag, ignore,
+				      sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -499,10 +277,9 @@ static ssize_t sm2_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(sm2_get_srx(ep), iov, desc, count, src_addr,
-				context, tag, ignore, sm2_ep_rx_flags(ep),
-				&sm2_get_srx(ep)->trecv_queue,
-				&sm2_get_srx(ep)->unexp_tagged_queue);
+	return util_srx_generic_trecv(ep->srx, iov, desc, count, src_addr,
+				      context, tag, ignore,
+				      sm2_ep_rx_flags(ep));
 }
 
 static ssize_t sm2_trecvmsg(struct fid_ep *ep_fid,
@@ -512,54 +289,10 @@ static ssize_t sm2_trecvmsg(struct fid_ep *ep_fid,
 
 	ep = container_of(ep_fid, struct sm2_ep, util_ep.ep_fid.fid);
 
-	return sm2_generic_recv(
-		sm2_get_srx(ep), msg->msg_iov, msg->desc, msg->iov_count,
-		msg->addr, msg->context, msg->tag, msg->ignore,
-		flags | ep->util_ep.rx_msg_flags, &sm2_get_srx(ep)->trecv_queue,
-		&sm2_get_srx(ep)->unexp_tagged_queue);
-}
-
-static ssize_t sm2_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
-			     void *desc, fi_addr_t src_addr, uint64_t tag,
-			     uint64_t ignore, void *context)
-{
-	struct iovec iov;
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	iov.iov_base = buf;
-	iov.iov_len = len;
-
-	return sm2_generic_recv(srx, &iov, &desc, 1, src_addr, context, tag,
-				ignore, srx->rx_op_flags, &srx->trecv_queue,
-				&srx->unexp_tagged_queue);
-}
-
-static ssize_t sm2_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
-			      void **desc, size_t count, fi_addr_t src_addr,
-			      uint64_t tag, uint64_t ignore, void *context)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, iov, desc, count, src_addr, context, tag,
-				ignore, srx->rx_op_flags, &srx->trecv_queue,
-				&srx->unexp_tagged_queue);
-}
-
-static ssize_t sm2_srx_trecvmsg(struct fid_ep *ep_fid,
-				const struct fi_msg_tagged *msg, uint64_t flags)
-{
-	struct sm2_srx_ctx *srx;
-
-	srx = container_of(ep_fid, struct sm2_srx_ctx, peer_srx.ep_fid);
-
-	return sm2_generic_recv(srx, msg->msg_iov, msg->desc, msg->iov_count,
-				msg->addr, msg->context, msg->tag, msg->ignore,
-				flags | srx->rx_msg_flags, &srx->trecv_queue,
-				&srx->unexp_tagged_queue);
+	return util_srx_generic_trecv(ep->srx, msg->msg_iov, msg->desc,
+				      msg->iov_count, msg->addr, msg->context,
+				      msg->tag, msg->ignore,
+				      flags | ep->util_ep.rx_msg_flags);
 }
 
 static ssize_t sm2_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -655,19 +388,6 @@ struct fi_ops_tagged sm2_no_recv_tag_ops = {
 	.recvmsg = fi_no_tagged_recvmsg,
 	.send = sm2_tsend,
 	.sendv = sm2_tsendv,
-	.sendmsg = sm2_tsendmsg,
-	.inject = sm2_tinject,
-	.senddata = sm2_tsenddata,
-	.injectdata = sm2_tinjectdata,
-};
-
-struct fi_ops_tagged sm2_srx_tag_ops = {
-	.size = sizeof(struct fi_ops_tagged),
-	.recv = sm2_srx_trecv,
-	.recvv = sm2_srx_trecvv,
-	.recvmsg = sm2_srx_trecvmsg,
-	.send = fi_no_tagged_send,
-	.sendv = fi_no_tagged_sendv,
 	.sendmsg = sm2_tsendmsg,
 	.inject = sm2_tinject,
 	.senddata = sm2_tsenddata,

--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -97,6 +97,7 @@ static int sm2_start_common(struct sm2_ep *ep,
 
 	if (err) {
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL, "Error processing op\n");
+		xfer_entry->hdr.op_flags &= ~FI_DELIVERY_COMPLETE;
 		ret = sm2_write_err_comp(ep->util_ep.rx_cq, rx_entry->context,
 					 comp_flags, rx_entry->tag, err);
 	} else {
@@ -105,10 +106,14 @@ static int sm2_start_common(struct sm2_ep *ep,
 			total_len, comp_buf, xfer_entry->hdr.sender_gid,
 			xfer_entry->hdr.tag, xfer_entry->hdr.cq_data);
 	}
+
 	if (ret) {
+		xfer_entry->hdr.op_flags &= ~FI_DELIVERY_COMPLETE;
 		FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
 			"Unable to process rx completion\n");
-	} else if (return_xfer_entry) {
+	}
+
+	if (return_xfer_entry) {
 		/* Return Free Queue Entries here */
 		sm2_fifo_write_back(ep, xfer_entry);
 	}

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -1,0 +1,1104 @@
+/*
+ * Copyright (c) Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+
+#include "ofi_enosys.h"
+#include "ofi_iov.h"
+#include "ofi_util.h"
+
+static struct util_rx_entry *util_alloc_rx_entry(struct util_srx_ctx *srx)
+{
+	return (struct util_rx_entry *) ofi_buf_alloc(srx->rx_pool);
+}
+
+static inline struct iovec *util_srx_iov(struct util_rx_entry *rx_entry)
+{
+	return (struct iovec *) ((char *) rx_entry + sizeof(*rx_entry));
+}
+
+static inline void **util_srx_desc(struct util_srx_ctx *srx,
+				   struct util_rx_entry *rx_entry)
+{
+	return (void **) ((char *) util_srx_iov(rx_entry) +
+			(sizeof(struct iovec) * srx->iov_limit));
+}
+
+static void util_init_rx_entry(struct util_rx_entry *entry,
+			       const struct iovec *iov, void **desc,
+			       size_t count, fi_addr_t addr, void *context,
+			       uint64_t tag, uint64_t flags)
+{
+	memcpy(entry->peer_entry.iov, iov, sizeof(*iov) * count);
+	if (desc)
+		memcpy(entry->peer_entry.desc, desc, sizeof(*desc) * count);
+	else
+		memset(entry->peer_entry.desc, 0, sizeof(*desc) * count);
+
+	entry->peer_entry.count = count;
+	entry->peer_entry.addr = addr;
+	entry->peer_entry.context = context;
+	entry->peer_entry.tag = tag;
+	entry->peer_entry.flags = flags;
+}
+
+static struct util_rx_entry *util_get_recv_entry(struct util_srx_ctx *srx,
+		const struct iovec *iov, void **desc, size_t count,
+		fi_addr_t addr, void *context, uint64_t tag, uint64_t ignore,
+		uint64_t flags)
+{
+	struct util_rx_entry *entry;
+
+	entry = util_alloc_rx_entry(srx);
+	if (!entry)
+		return NULL;
+
+	util_init_rx_entry(entry, iov, desc, count, addr, context, tag, flags);
+
+	entry->peer_entry.owner_context = NULL;
+
+	entry->multi_recv_ref = 0;
+	entry->ignore = ignore;
+	entry->seq_no = srx->rx_seq_no++;
+
+	return entry;
+}
+
+static struct util_rx_entry *util_init_unexp(struct util_srx_ctx *srx,
+			fi_addr_t addr, uint64_t size, uint64_t tag)
+{
+	struct util_rx_entry *util_entry;
+
+	util_entry = util_alloc_rx_entry(srx);
+	if (!util_entry)
+		return NULL;
+
+	util_entry->peer_entry.owner_context = NULL;
+	util_entry->peer_entry.size = size;
+	util_entry->peer_entry.addr = addr;
+	util_entry->peer_entry.tag = tag;
+
+	return util_entry;
+}
+
+static bool util_adjust_multi_recv(struct util_srx_ctx *srx,
+		struct fi_peer_rx_entry *rx_entry, size_t len)
+{
+	size_t left;
+	void *new_base;
+
+	left = rx_entry->iov[0].iov_len - len;
+
+	new_base = (void *) ((uintptr_t) rx_entry->iov[0].iov_base + len);
+	rx_entry->iov[0].iov_len = left;
+	rx_entry->iov[0].iov_base = new_base;
+	rx_entry->size = left;
+
+	return left < srx->min_multi_recv_size;
+}
+
+static struct util_rx_entry *util_process_multi_recv(struct util_srx_ctx *srx,
+		struct slist *queue, fi_addr_t addr, size_t size,
+		struct util_rx_entry *owner_entry)
+{
+	struct util_rx_entry *util_entry;
+
+	util_entry = util_get_recv_entry(srx,
+					 owner_entry->peer_entry.iov,
+					 owner_entry->peer_entry.desc,
+					 owner_entry->peer_entry.count, addr,
+					 owner_entry->peer_entry.context,
+					 owner_entry->peer_entry.tag,
+					 owner_entry->ignore,
+					 owner_entry->peer_entry.flags &
+					 (~FI_MULTI_RECV));
+	if (!util_entry)
+		return NULL;
+
+	if (util_adjust_multi_recv(srx, &owner_entry->peer_entry, size))
+		slist_remove_head(queue);
+
+	util_entry->peer_entry.owner_context = owner_entry;
+	owner_entry->multi_recv_ref++;
+
+	return util_entry;
+}
+
+static int util_match_msg(struct fid_peer_srx *srx, fi_addr_t addr, size_t size,
+			  struct fi_peer_rx_entry **rx_entry)
+{
+	struct util_srx_ctx *srx_ctx;
+	struct util_rx_entry *util_entry;
+	struct slist_entry *head;
+	int ret = FI_SUCCESS;
+
+	srx_ctx = srx->ep_fid.fid.context;
+	if (slist_empty(&srx_ctx->msg_queue)) {
+		util_entry = util_init_unexp(srx_ctx, addr, size, 0);
+		if (!util_entry)
+			return -FI_ENOMEM;
+		util_entry->peer_entry.srx = srx;
+		ret = -FI_ENOENT;
+	} else {
+		head = srx_ctx->msg_queue.head;
+		util_entry = container_of(head, struct util_rx_entry,
+					  peer_entry);
+		if (util_entry->peer_entry.flags & FI_MULTI_RECV) {
+			util_entry = util_process_multi_recv(srx_ctx,
+				&srx_ctx->msg_queue, addr, size, util_entry);
+			if (!util_entry) {
+				FI_WARN(&core_prov, FI_LOG_EP_CTRL,
+					"cannot allocate multi receive "
+					"buffer\n");
+				return -FI_ENOMEM;
+			}
+		} else {
+			(void) slist_remove_head(&srx_ctx->msg_queue);
+		}
+		util_entry->peer_entry.srx = srx;
+		srx_ctx->update_func(srx_ctx, util_entry);
+	}
+	*rx_entry = &util_entry->peer_entry;
+	return ret;
+}
+
+static int util_get_msg(struct fid_peer_srx *srx, fi_addr_t addr,
+		        size_t size, struct fi_peer_rx_entry **rx_entry)
+{
+	struct util_srx_ctx *srx_ctx;
+	struct util_rx_entry *util_entry, *any_entry;
+	struct slist *queue;
+
+	srx_ctx = srx->ep_fid.fid.context;
+	queue = addr == FI_ADDR_UNSPEC ? NULL:
+		ofi_array_at(&srx_ctx->src_recv_queues, addr);
+
+	if (!queue || slist_empty(queue))
+		return util_match_msg(srx, addr, size, rx_entry);
+
+	util_entry = container_of(queue->head, struct util_rx_entry,
+				  peer_entry);
+	if (!slist_empty(&srx_ctx->msg_queue)) {
+		any_entry = container_of(&srx_ctx->msg_queue.head,
+					 struct util_rx_entry, peer_entry);
+		if (any_entry->seq_no <= util_entry->seq_no) {
+			queue = &srx_ctx->msg_queue;
+			util_entry = any_entry;
+		}
+	}
+
+	if (util_entry->peer_entry.flags & FI_MULTI_RECV) {
+		util_entry = util_process_multi_recv(srx_ctx, queue, addr, size,
+						     util_entry);
+		if (!util_entry) {
+			FI_WARN(&core_prov, FI_LOG_EP_CTRL,
+				"cannot allocate multi receive buffer\n");
+			return -FI_ENOMEM;
+		}
+	} else {
+		(void) slist_remove_head(queue);
+	}
+	util_entry->peer_entry.srx = srx;
+	srx_ctx->update_func(srx_ctx, util_entry);
+	*rx_entry = &util_entry->peer_entry;
+	return FI_SUCCESS;
+}
+
+static int util_match_tag(struct fid_peer_srx *srx, fi_addr_t addr,
+			  size_t size, uint64_t tag,
+			  struct fi_peer_rx_entry **rx_entry)
+{
+	struct util_srx_ctx *srx_ctx;
+	struct util_rx_entry *util_entry;
+	struct slist_entry *item, *prev;
+	int ret = FI_SUCCESS;
+
+	srx_ctx = srx->ep_fid.fid.context;
+	slist_foreach(&srx_ctx->tag_queue, item, prev) {
+		util_entry = container_of(item, struct util_rx_entry,
+					  peer_entry);
+		if (ofi_match_tag(util_entry->peer_entry.tag,
+				  util_entry->ignore, tag)) {
+			util_entry->peer_entry.srx = srx;
+			srx_ctx->update_func(srx_ctx, util_entry);
+			slist_remove(&srx_ctx->tag_queue, item, prev);
+			goto out;
+		}
+	}
+
+	util_entry = util_init_unexp(srx_ctx, addr, size, tag);
+	if (!util_entry)
+		return -FI_ENOMEM;
+	ret = -FI_ENOENT;
+	util_entry->peer_entry.srx = srx;
+out:
+	*rx_entry = &util_entry->peer_entry;
+	return ret;
+}
+
+static int util_get_tag(struct fid_peer_srx *srx, fi_addr_t addr,
+			size_t size, uint64_t tag,
+			struct fi_peer_rx_entry **rx_entry)
+{
+	struct util_srx_ctx *srx_ctx;
+	struct slist *queue;
+	struct slist_entry *any_item, *any_prev;
+	struct slist_entry *item, *prev;
+	struct util_rx_entry *util_entry, *any_entry;
+	int ret = FI_SUCCESS;
+
+	srx_ctx = srx->ep_fid.fid.context;
+	queue = addr == FI_ADDR_UNSPEC ? NULL:
+		ofi_array_at(&srx_ctx->src_trecv_queues, addr);
+
+	if (!queue || slist_empty(queue))
+		return util_match_tag(srx, addr, size, tag, rx_entry);
+
+	slist_foreach(queue, item, prev) {
+		util_entry = container_of(item, struct util_rx_entry,
+					  peer_entry);
+		if (ofi_match_tag(util_entry->peer_entry.tag,
+				  util_entry->ignore, tag))
+			goto check_any;
+	}
+	return util_match_tag(srx, addr, size, tag, rx_entry);
+
+check_any:
+	slist_foreach(&srx_ctx->tag_queue, any_item, any_prev) {
+		any_entry = container_of(any_item, struct util_rx_entry,
+					 peer_entry);
+		if (any_entry->seq_no > util_entry->seq_no)
+			break;
+
+		if (ofi_match_tag(any_entry->peer_entry.tag, any_entry->ignore,
+				  tag)) {
+			queue = &srx_ctx->tag_queue;
+			util_entry = any_entry;
+			item = any_item;
+			prev = any_prev;
+			break;
+		}
+	}
+	util_entry->peer_entry.srx = srx;
+	srx_ctx->update_func(srx_ctx, util_entry);
+	*rx_entry = &util_entry->peer_entry;
+	slist_remove(queue, item, prev);
+	return ret;
+}
+
+static int util_queue_msg(struct fi_peer_rx_entry *rx_entry)
+{
+	struct util_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
+	struct util_rx_entry *util_entry;
+	struct dlist_entry *queue;
+
+	queue = rx_entry->addr == FI_ADDR_UNSPEC ?
+		&srx_ctx->unspec_unexp_msg_queue :
+		ofi_array_at(&srx_ctx->src_unexp_msg_queues, rx_entry->addr);
+
+	util_entry = container_of(rx_entry, struct util_rx_entry, peer_entry);
+	dlist_insert_tail((struct dlist_entry *) rx_entry, queue);
+	dlist_insert_tail(&util_entry->entry, &srx_ctx->all_unexp_msg);
+	return FI_SUCCESS;
+}
+
+static int util_queue_tag(struct fi_peer_rx_entry *rx_entry)
+{
+	struct util_srx_ctx *srx_ctx = rx_entry->srx->ep_fid.fid.context;
+	struct util_rx_entry *util_entry;
+	struct dlist_entry *queue;
+
+	queue = rx_entry->addr == FI_ADDR_UNSPEC ?
+		&srx_ctx->unspec_unexp_tag_queue :
+		ofi_array_at(&srx_ctx->src_unexp_tag_queues, rx_entry->addr);
+
+	util_entry = container_of(rx_entry, struct util_rx_entry, peer_entry);
+	dlist_insert_tail((struct dlist_entry *) rx_entry, queue);
+	dlist_insert_tail(&util_entry->entry, &srx_ctx->all_unexp_tag);
+	return FI_SUCCESS;
+}
+
+static void util_free_entry(struct fi_peer_rx_entry *entry)
+{
+	struct util_srx_ctx *srx;
+	struct util_rx_entry *util_entry, *owner_entry;
+
+	srx = (struct util_srx_ctx *) entry->srx->ep_fid.fid.context;
+	util_entry = container_of(entry, struct util_rx_entry, peer_entry);
+	if (entry->owner_context) {
+		owner_entry = (struct util_rx_entry *) entry->owner_context;
+		if (!--owner_entry->multi_recv_ref &&
+		    owner_entry->peer_entry.size < srx->min_multi_recv_size) {
+			if (ofi_peer_cq_write(srx->cq,
+					      owner_entry->peer_entry.context,
+					      FI_MULTI_RECV, 0, NULL, 0, 0,
+					      FI_ADDR_NOTAVAIL)) {
+				FI_WARN(&core_prov, FI_LOG_EP_CTRL,
+					"cannot write MULTI_RECV completion\n");
+			}
+			ofi_buf_free(owner_entry);
+		}
+	}
+	ofi_buf_free(util_entry);
+}
+
+static void util_foreach_unspec(struct fid_peer_srx *srx,
+		fi_addr_t (*get_addr)(struct fi_peer_rx_entry *))
+{
+	struct util_srx_ctx *srx_ctx;
+	struct fi_peer_rx_entry *rx_entry;
+	struct dlist_entry *item, *tmp;
+	struct dlist_entry *queue;
+
+	srx_ctx = srx->ep_fid.fid.context;
+
+	dlist_foreach_safe(&srx_ctx->unspec_unexp_msg_queue, item, tmp) {
+		rx_entry = (struct fi_peer_rx_entry *) item;
+		rx_entry->addr = get_addr(rx_entry);
+		if (rx_entry->addr != FI_ADDR_UNSPEC) {
+			dlist_remove(item);
+			queue = ofi_array_at(&srx_ctx->src_unexp_msg_queues,
+					     rx_entry->addr);
+			dlist_insert_tail(item, queue);
+		}
+	}
+
+	dlist_foreach_safe(&srx_ctx->unspec_unexp_tag_queue, item, tmp) {
+		rx_entry = (struct fi_peer_rx_entry *) item;
+		rx_entry->addr = get_addr(rx_entry);
+		if (rx_entry->addr != FI_ADDR_UNSPEC) {
+			dlist_remove(item);
+			queue = ofi_array_at(&srx_ctx->src_unexp_tag_queues,
+					     rx_entry->addr);
+			dlist_insert_tail(item, queue);
+		}
+	}
+}
+
+static struct fi_ops_srx_owner util_srx_owner_ops = {
+	.size = sizeof(struct fi_ops_srx_owner),
+	.get_msg = util_get_msg,
+	.get_tag = util_get_tag,
+	.queue_msg = util_queue_msg,
+	.queue_tag = util_queue_tag,
+	.foreach_unspec_addr = util_foreach_unspec,
+	.free_entry = util_free_entry,
+};
+
+static struct util_rx_entry *util_find_unspec_msg(struct util_srx_ctx *srx,
+						   fi_addr_t addr)
+{
+	if (dlist_empty(&srx->all_unexp_msg))
+		return NULL;
+
+	return container_of(srx->all_unexp_msg.next, struct util_rx_entry,
+			    entry);
+}
+
+static struct util_rx_entry *util_find_unexp_msg(struct util_srx_ctx *srx,
+			fi_addr_t addr)
+{
+	struct dlist_entry *queue;
+
+	if (addr == FI_ADDR_UNSPEC)
+		return util_find_unspec_msg(srx, addr);
+
+	queue = ofi_array_at(&srx->src_unexp_msg_queues, addr);
+	if (dlist_empty(queue))
+		return NULL;
+
+	return container_of(queue->next, struct util_rx_entry, peer_entry);
+}
+
+static struct util_rx_entry *util_remove_unexp_msg(struct util_srx_ctx *srx,
+			fi_addr_t addr)
+{
+	struct util_rx_entry *util_entry;
+
+	util_entry = util_find_unexp_msg(srx, addr);
+	if (!util_entry)
+		return NULL;
+
+	dlist_remove((struct dlist_entry *) &util_entry->peer_entry);
+	dlist_remove(&util_entry->entry);
+
+	return util_entry;
+}
+
+static ssize_t util_generic_mrecv(struct util_srx_ctx *srx,
+		const struct iovec *iov, void **desc, size_t iov_count,
+		fi_addr_t addr, void *context, uint64_t flags)
+{
+	struct util_rx_entry *rx_entry, *mrecv_entry;
+	struct slist *queue;
+	bool buf_done = false;
+	int ret;
+
+	assert(flags & FI_MULTI_RECV && iov_count == 1);
+
+	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
+
+	mrecv_entry = util_get_recv_entry(srx, iov, desc, iov_count, addr,
+					  context, 0, 0, flags);
+	if (!mrecv_entry)
+		return -FI_ENOMEM;
+
+	mrecv_entry->peer_entry.size = ofi_total_iov_len(iov, iov_count);
+
+	rx_entry = util_remove_unexp_msg(srx, addr);
+	while (rx_entry) {
+		util_init_rx_entry(rx_entry, mrecv_entry->peer_entry.iov, desc,
+				   iov_count, addr, context, 0,
+				   flags & (~FI_MULTI_RECV));
+		mrecv_entry->multi_recv_ref++;
+		rx_entry->peer_entry.owner_context = mrecv_entry;
+
+		if (util_adjust_multi_recv(srx, &mrecv_entry->peer_entry,
+					   rx_entry->peer_entry.size))
+			buf_done = true;
+
+		srx->update_func(srx, rx_entry);
+		ret = rx_entry->peer_entry.srx->peer_ops->start_msg(
+							&rx_entry->peer_entry);
+		if (ret || buf_done)
+			return ret;
+
+		rx_entry = util_remove_unexp_msg(srx, addr);
+	}
+
+	queue = addr == FI_ADDR_UNSPEC ? &srx->msg_queue:
+		ofi_array_at(&srx->src_recv_queues, addr);
+	slist_insert_tail((struct slist_entry *)(&mrecv_entry->peer_entry),
+			  queue);
+	return FI_SUCCESS;
+}
+
+static struct util_rx_entry *util_find_unspec_tag(struct util_srx_ctx *srx,
+			uint64_t tag, uint64_t ignore)
+{
+	struct util_rx_entry *util_entry;
+	struct dlist_entry *item;
+
+	if (dlist_empty(&srx->all_unexp_tag))
+		return NULL;
+
+	dlist_foreach(&srx->all_unexp_tag, item) {
+		util_entry = container_of(item, struct util_rx_entry, entry);
+		if (ofi_match_tag(tag, ignore, util_entry->peer_entry.tag))
+			return util_entry;
+	}
+	return NULL;
+}
+
+static struct util_rx_entry *util_find_unexp_tag(struct util_srx_ctx *srx,
+			fi_addr_t addr, uint64_t tag, uint64_t ignore)
+{
+	struct dlist_entry *queue, *item;
+	struct util_rx_entry *util_entry;
+
+	if (addr == FI_ADDR_UNSPEC)
+		return util_find_unspec_tag(srx, tag, ignore);
+
+	queue = ofi_array_at(&srx->src_unexp_tag_queues, addr);
+	if (dlist_empty(queue))
+		return NULL;
+
+	dlist_foreach(queue, item) {
+		util_entry = container_of(item, struct util_rx_entry,
+					  peer_entry);
+		if (ofi_match_tag(tag, ignore, util_entry->peer_entry.tag))
+			return util_entry;
+	}
+	return NULL;
+}
+
+static struct util_rx_entry *util_remove_unexp_tag(struct util_srx_ctx *srx,
+			fi_addr_t addr, uint64_t tag, uint64_t ignore)
+{
+	struct util_rx_entry *util_entry;
+
+	util_entry = util_find_unexp_tag(srx, addr, tag, ignore);
+	if (!util_entry)
+		return NULL;
+
+	dlist_remove((struct dlist_entry *) &util_entry->peer_entry);
+	dlist_remove(&util_entry->entry);
+
+	return util_entry;
+}
+
+static ssize_t util_srx_peek(struct util_srx_ctx *srx, const struct iovec *iov,
+			     void **desc, size_t iov_count, fi_addr_t addr,
+			     void *context, uint64_t tag, uint64_t ignore,
+			     uint64_t flags)
+{
+	struct util_rx_entry *rx_entry;
+	int ret = FI_SUCCESS;
+
+	rx_entry = util_find_unexp_tag(srx, addr, tag, ignore);
+	if (!rx_entry) {
+		FI_DBG(&core_prov, FI_LOG_EP_CTRL, "Message not found\n");
+		return ofi_cq_write_error_peek(srx->cq, tag, context);
+	}
+	FI_DBG(&core_prov, FI_LOG_EP_CTRL, "Message found\n");
+
+	if (flags & (FI_CLAIM | FI_DISCARD)) {
+		dlist_remove((struct dlist_entry *) &rx_entry->peer_entry);
+		dlist_remove(&rx_entry->entry);
+
+		if (flags & FI_DISCARD) {
+			ret = rx_entry->peer_entry.srx->peer_ops->discard_tag(
+							&rx_entry->peer_entry);
+			if (ret) {
+				FI_WARN(&core_prov, FI_LOG_EP_CTRL,
+					"Error discarding message with peer\n");
+			}
+		}
+		((struct fi_context *)context)->internal[0] = rx_entry;
+	}
+
+	return ofi_cq_write(srx->cq, context, FI_TAGGED | FI_RECV,
+			    rx_entry->peer_entry.size, NULL, 0,
+			    rx_entry->peer_entry.tag);
+}
+
+ssize_t util_srx_generic_trecv(struct fid_ep *ep_fid, const struct iovec *iov,
+			       void **desc, size_t iov_count, fi_addr_t addr,
+			       void *context, uint64_t tag, uint64_t ignore,
+			       uint64_t flags)
+{
+	struct util_srx_ctx *srx;
+	struct util_rx_entry *rx_entry;
+	struct slist *queue;
+	int ret = FI_SUCCESS;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+	assert(iov_count <= srx->iov_limit);
+	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
+
+	if (flags & FI_PEEK) {
+		return util_srx_peek(srx, iov, desc, iov_count, addr,
+				    context, tag, ignore, flags);
+	}
+
+	if (flags & FI_DISCARD) {
+		assert(flags & FI_CLAIM);
+		rx_entry = (struct util_rx_entry *)
+				(((struct fi_context *) context)->internal[0]);
+		ret = rx_entry->peer_entry.srx->peer_ops->discard_tag(
+							&rx_entry->peer_entry);
+		if (ret) {
+			FI_WARN(&core_prov, FI_LOG_EP_CTRL,
+				"Error discarding message with peer\n");
+		}
+		return ofi_cq_write(srx->cq, context, FI_TAGGED | FI_RECV,
+				    rx_entry->peer_entry.size, NULL, 0,
+				    rx_entry->peer_entry.tag);
+	}
+
+	if (flags & FI_CLAIM) {
+		rx_entry = (struct util_rx_entry *)
+				(((struct fi_context *) context)->internal[0]);
+	} else {
+		rx_entry = util_remove_unexp_tag(srx, addr, tag, ignore);
+		if (!rx_entry) {
+			queue = addr == FI_ADDR_UNSPEC ? &srx->tag_queue:
+				ofi_array_at(&srx->src_trecv_queues, addr);
+			rx_entry = util_get_recv_entry(srx, iov, desc,
+						iov_count, addr, context, tag,
+						ignore, flags);
+			if (!rx_entry)
+				return -FI_ENOMEM;
+			slist_insert_tail((struct slist_entry *)
+					  (&rx_entry->peer_entry), queue);
+			return FI_SUCCESS;
+		}
+	}
+	util_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context, tag,
+			   flags);
+
+	srx->update_func(srx, rx_entry);
+	return rx_entry->peer_entry.srx->peer_ops->start_tag(
+					&rx_entry->peer_entry);
+}
+
+ssize_t util_srx_generic_recv(struct fid_ep *ep_fid, const struct iovec *iov,
+			      void **desc, size_t iov_count, fi_addr_t addr,
+			      void *context, uint64_t flags)
+{
+	struct util_srx_ctx *srx;
+	struct util_rx_entry *rx_entry;
+	struct slist *queue;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	if (flags & FI_MULTI_RECV)
+		return util_generic_mrecv(srx, iov, desc, iov_count, addr,
+					  context, flags);
+
+	assert(iov_count <= srx->iov_limit);
+	addr = srx->dir_recv ? addr : FI_ADDR_UNSPEC;
+
+	rx_entry = util_remove_unexp_msg(srx, addr);
+	if (!rx_entry) {
+		queue = addr == FI_ADDR_UNSPEC ? &srx->msg_queue :
+			ofi_array_at(&srx->src_recv_queues, addr);
+		rx_entry = util_get_recv_entry(srx, iov, desc, iov_count, addr,
+					       context, 0, 0, flags);
+		if (!rx_entry)
+			return -FI_ENOMEM;
+		slist_insert_tail((struct slist_entry *)
+				  (&rx_entry->peer_entry), queue);
+		return FI_SUCCESS;
+	}
+
+	util_init_rx_entry(rx_entry, iov, desc, iov_count, addr, context, 0,
+			   flags);
+
+	srx->update_func(srx, rx_entry);
+	return rx_entry->peer_entry.srx->peer_ops->start_msg(
+						&rx_entry->peer_entry);
+}
+
+static ssize_t util_srx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+				uint64_t flags)
+{
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	return util_srx_generic_recv(ep_fid, msg->msg_iov, msg->desc,
+				     msg->iov_count, msg->addr, msg->context,
+				     flags | srx->rx_msg_flags);
+}
+
+static ssize_t util_srx_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
+			      void **desc, size_t count, fi_addr_t src_addr,
+			      void *context)
+{
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	return util_srx_generic_recv(ep_fid, iov, desc, count, src_addr,
+				    context, srx->rx_op_flags);
+}
+
+static ssize_t util_srx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+			     void *desc, fi_addr_t src_addr, void *context)
+{
+	struct iovec iov;
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	iov.iov_base = buf;
+	iov.iov_len = len;
+
+	return util_srx_generic_recv(ep_fid, &iov, &desc, 1, src_addr, context,
+				     srx->rx_op_flags);
+}
+
+struct fi_ops_msg util_srx_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = util_srx_recv,
+	.recvv = util_srx_recvv,
+	.recvmsg = util_srx_recvmsg,
+	.send = fi_no_msg_send,
+	.sendv = fi_no_msg_sendv,
+	.sendmsg = fi_no_msg_sendmsg,
+	.inject = fi_no_msg_inject,
+	.senddata = fi_no_msg_senddata,
+	.injectdata = fi_no_msg_injectdata,
+};
+
+static ssize_t util_srx_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
+			      void *desc, fi_addr_t src_addr, uint64_t tag,
+			      uint64_t ignore, void *context)
+{
+	struct iovec iov;
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	iov.iov_base = buf;
+	iov.iov_len = len;
+
+	return util_srx_generic_trecv(ep_fid, &iov, &desc, 1, src_addr, context,
+				      tag, ignore, srx->rx_op_flags);
+}
+
+static ssize_t util_srx_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
+			       void **desc, size_t count, fi_addr_t src_addr,
+			       uint64_t tag, uint64_t ignore, void *context)
+{
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	return util_srx_generic_trecv(ep_fid, iov, desc, count, src_addr,
+				      context, tag, ignore, srx->rx_op_flags);
+}
+
+static ssize_t util_srx_trecvmsg(struct fid_ep *ep_fid,
+			const struct fi_msg_tagged *msg, uint64_t flags)
+{
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	return util_srx_generic_trecv(ep_fid, msg->msg_iov, msg->desc,
+				      msg->iov_count, msg->addr, msg->context,
+				      msg->tag, msg->ignore,
+				      flags | srx->rx_msg_flags);
+}
+
+struct fi_ops_tagged util_srx_tag_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = util_srx_trecv,
+	.recvv = util_srx_trecvv,
+	.recvmsg = util_srx_trecvmsg,
+	.send = fi_no_tagged_send,
+	.sendv = fi_no_tagged_sendv,
+	.sendmsg = fi_no_tagged_sendmsg,
+	.inject = fi_no_tagged_inject,
+	.senddata = fi_no_tagged_senddata,
+	.injectdata = fi_no_tagged_injectdata,
+};
+
+int util_srx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	struct util_srx_ctx *srx;
+
+	if (flags != FI_RECV || bfid->fclass != FI_CLASS_CQ)
+		return -FI_EINVAL;
+
+	srx = container_of(fid, struct util_srx_ctx, peer_srx.ep_fid.fid);
+	srx->cq = container_of(bfid, struct util_cq, cq_fid.fid);
+	ofi_atomic_inc32(&srx->cq->ref);
+	return FI_SUCCESS;
+}
+
+static int util_cancel_entry(struct util_srx_ctx *srx, uint64_t flags,
+			     struct util_rx_entry *rx_entry)
+{
+	struct fi_cq_err_entry err_entry;
+	int ret;
+
+	err_entry.op_context = rx_entry->peer_entry.context;
+	err_entry.flags = flags;
+	err_entry.tag = rx_entry->peer_entry.tag;
+	err_entry.err = FI_ECANCELED;
+	err_entry.prov_errno = -FI_ECANCELED;
+
+	ret = ofi_peer_cq_write_error(srx->cq, &err_entry);
+	ofi_buf_free(rx_entry);
+	return ret ? ret : 1;
+}
+
+static int util_cleanup_queues(struct ofi_dyn_arr *arr, void *list,
+			       void *context)
+{
+	struct util_srx_ctx *srx = context;
+	struct slist *queue = list;
+	struct slist_entry *item;
+	struct util_rx_entry *rx_entry;
+	uint64_t flags;
+
+	flags = arr == &srx->src_trecv_queues ?
+		FI_TAGGED | FI_RECV : FI_MSG | FI_RECV;
+
+	while (!slist_empty(queue)) {
+		item = slist_remove_head(queue);
+		rx_entry = container_of(item, struct util_rx_entry, peer_entry);
+		(void) util_cancel_entry(srx, flags, rx_entry);
+	}
+	return FI_SUCCESS;
+}
+
+int util_srx_close(struct fid *fid)
+{
+	struct util_srx_ctx *srx;
+	struct util_rx_entry *rx_entry;
+	struct slist_entry *entry;
+
+	srx = container_of(fid, struct util_srx_ctx, peer_srx.ep_fid.fid);
+	if (!srx)
+		return -FI_EINVAL;
+
+	(void)ofi_array_iter(&srx->src_recv_queues, srx, util_cleanup_queues);
+	(void)ofi_array_iter(&srx->src_trecv_queues, srx, util_cleanup_queues);
+	ofi_array_destroy(&srx->src_recv_queues);
+	ofi_array_destroy(&srx->src_trecv_queues);
+
+	while (!slist_empty(&srx->msg_queue)) {
+		entry = slist_remove_head(&srx->msg_queue);
+		(void) util_cancel_entry(srx, FI_SEND | FI_MSG,
+				container_of(entry, struct util_rx_entry,
+				             peer_entry));
+	}
+
+	while (!slist_empty(&srx->tag_queue)) {
+		entry = slist_remove_head(&srx->tag_queue);
+		(void) util_cancel_entry(srx, FI_SEND | FI_TAGGED,
+				container_of(entry, struct util_rx_entry,
+					     peer_entry));
+	}
+
+	while (!dlist_empty(&srx->all_unexp_msg)) {
+		dlist_pop_front(&srx->all_unexp_msg, struct util_rx_entry,
+				rx_entry, entry);
+		rx_entry->peer_entry.srx->peer_ops->discard_msg(
+							&rx_entry->peer_entry);
+		ofi_buf_free(rx_entry);
+	}
+
+	while (!dlist_empty(&srx->all_unexp_tag)) {
+		dlist_pop_front(&srx->all_unexp_tag, struct util_rx_entry,
+				rx_entry, entry);
+		rx_entry->peer_entry.srx->peer_ops->discard_tag(
+							&rx_entry->peer_entry);
+		ofi_buf_free(rx_entry);
+	}
+
+	ofi_array_destroy(&srx->src_unexp_msg_queues);
+	ofi_array_destroy(&srx->src_unexp_tag_queues);
+
+	ofi_atomic_dec32(&srx->cq->ref);
+	ofi_bufpool_destroy(srx->rx_pool);
+	ofi_mutex_destroy(&srx->lock);
+	free(srx);
+
+	return FI_SUCCESS;
+}
+
+static struct fi_ops util_srx_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_srx_close,
+	.bind = util_srx_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static bool util_cancel_recv(struct util_srx_ctx *srx, struct slist *queue,
+			     uint64_t flags, void *context)
+{
+	struct slist_entry *item, *prev;
+	struct util_rx_entry *rx_entry;
+
+	slist_foreach(queue, item, prev) {
+		rx_entry = container_of(item, struct util_rx_entry, peer_entry);
+		if (rx_entry->peer_entry.context == context) {
+			slist_remove(queue, item, prev);
+			util_cancel_entry(srx, flags, rx_entry);
+			return true;
+		}
+	}
+	return false;
+}
+
+static int util_cancel_src(struct ofi_dyn_arr *arr, void *list, void *context)
+{
+	struct util_srx_ctx *srx;
+	struct slist *queue = list;
+	uint64_t flags;
+
+	srx = container_of(arr, struct util_srx_ctx, src_trecv_queues);
+
+	flags = arr == &srx->src_trecv_queues ?
+		FI_TAGGED | FI_RECV : FI_MSG | FI_RECV;
+
+	return (int) util_cancel_recv(srx, queue, flags, context);
+}
+
+static ssize_t util_srx_cancel(fid_t ep_fid, void *context)
+{
+	struct util_srx_ctx *srx;
+
+	srx = container_of(ep_fid, struct util_srx_ctx, peer_srx.ep_fid);
+
+	srx->lock_acquire(&srx->lock);
+	if (util_cancel_recv(srx, &srx->tag_queue, FI_TAGGED | FI_RECV,
+			     context))
+		goto out;
+
+	if (util_cancel_recv(srx, &srx->msg_queue, FI_MSG | FI_RECV, context))
+		goto out;
+
+	if (ofi_array_iter(&srx->src_trecv_queues, context, util_cancel_src))
+		goto out;
+
+	(void) ofi_array_iter(&srx->src_recv_queues, context, util_cancel_src);
+
+out:
+	srx->lock_release(&srx->lock);
+	return FI_SUCCESS;
+}
+
+static int util_srx_getopt(fid_t fid, int level, int optname,
+		           void *optval, size_t *optlen)
+{
+	struct util_srx_ctx *srx =
+		container_of(fid, struct util_srx_ctx, peer_srx.ep_fid.fid);
+
+	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
+		return -FI_ENOPROTOOPT;
+
+	*(size_t *)optval = srx->min_multi_recv_size;
+	*optlen = sizeof(size_t);
+
+	return FI_SUCCESS;
+}
+
+static int util_srx_setopt(fid_t fid, int level, int optname,
+		           const void *optval, size_t optlen)
+{
+	struct util_srx_ctx *srx =
+		container_of(fid, struct util_srx_ctx, peer_srx.ep_fid.fid);
+
+	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
+		return -FI_ENOPROTOOPT;
+
+	srx->min_multi_recv_size = *(size_t *)optval;
+
+	return FI_SUCCESS;
+}
+
+static struct fi_ops_ep util_srx_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = util_srx_cancel,
+	.getopt = util_srx_getopt,
+	.setopt = util_srx_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+static void util_rx_entry_init_fn(struct ofi_bufpool_region *region, void *buf)
+{
+	struct util_rx_entry *rx_entry = (struct util_rx_entry *) buf;
+	struct util_srx_ctx *srx = (struct util_srx_ctx *)
+					region->pool->attr.context;
+
+	rx_entry->peer_entry.iov = util_srx_iov(rx_entry);
+	rx_entry->peer_entry.desc = util_srx_desc(srx, rx_entry);
+}
+
+static void util_srx_init_slist(struct ofi_dyn_arr *arr, void *item)
+{
+	slist_init((struct slist *) item);
+}
+
+static void util_srx_init_dlist(struct ofi_dyn_arr *arr, void *item)
+{
+	dlist_init((struct dlist_entry *) item);
+}
+
+int util_ep_srx_context(struct util_domain *domain, size_t rx_size,
+			size_t iov_limit, size_t default_min_multi_recv,
+			ofi_update_func_t update_func, struct fid_ep **rx_ep)
+{
+	struct util_srx_ctx *srx;
+	struct ofi_bufpool_attr pool_attr;
+	int ret = FI_SUCCESS;
+
+	srx = calloc(1, sizeof(*srx));
+	if (!srx)
+		return -FI_ENOMEM;
+
+	ofi_mutex_init(&srx->lock);
+	if (domain->threading != FI_THREAD_SAFE) {
+		srx->lock_acquire = ofi_mutex_lock_noop;
+		srx->lock_release = ofi_mutex_unlock_noop;
+	} else {
+		srx->lock_acquire = ofi_mutex_lock_op;
+		srx->lock_release = ofi_mutex_unlock_op;
+	}
+
+	ofi_array_init(&srx->src_unexp_msg_queues, sizeof(struct dlist_entry),
+		       util_srx_init_dlist);
+	ofi_array_init(&srx->src_unexp_tag_queues, sizeof(struct dlist_entry),
+		       util_srx_init_dlist);
+
+	ofi_array_init(&srx->src_recv_queues, sizeof(struct slist),
+		       util_srx_init_slist);
+	ofi_array_init(&srx->src_trecv_queues, sizeof(struct slist),
+		       util_srx_init_slist);
+
+	slist_init(&srx->msg_queue);
+	slist_init(&srx->tag_queue);
+
+	dlist_init(&srx->all_unexp_msg);
+	dlist_init(&srx->all_unexp_tag);
+
+	dlist_init(&srx->unspec_unexp_msg_queue);
+	dlist_init(&srx->unspec_unexp_tag_queue);
+	srx->rx_seq_no = 0;
+
+	//each entry has the iovs and descriptors stored at the end of the entry
+	//calculate how much space each entry needs based on provider iov limits
+	pool_attr.size = sizeof(struct util_rx_entry) +
+		(sizeof(struct iovec) + sizeof(void *)) * iov_limit;
+	pool_attr.alignment = 16;
+	pool_attr.max_cnt = 0,
+	pool_attr.chunk_cnt = rx_size,
+	pool_attr.alloc_fn = NULL;
+	pool_attr.free_fn = NULL;
+	pool_attr.init_fn = util_rx_entry_init_fn;
+	pool_attr.context = srx;
+	pool_attr.flags = OFI_BUFPOOL_NO_TRACK;
+	ret = ofi_bufpool_create_attr(&pool_attr, &srx->rx_pool);
+	if (ret) {
+		free(srx);
+		return ret;
+	}
+
+	srx->min_multi_recv_size = default_min_multi_recv;
+	srx->iov_limit = iov_limit;
+	srx->dir_recv = domain->info_domain_caps & FI_DIRECTED_RECV;
+	srx->update_func = update_func;
+
+	srx->peer_srx.owner_ops = &util_srx_owner_ops;
+	srx->peer_srx.peer_ops = NULL;
+
+	srx->peer_srx.ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
+	srx->peer_srx.ep_fid.fid.context = srx;
+	srx->peer_srx.ep_fid.fid.ops = &util_srx_fid_ops;
+	srx->peer_srx.ep_fid.ops = &util_srx_ops;
+
+	srx->peer_srx.ep_fid.msg = &util_srx_msg_ops;
+	srx->peer_srx.ep_fid.tagged = &util_srx_tag_ops;
+	*rx_ep = &srx->peer_srx.ep_fid;
+
+	return FI_SUCCESS;
+}

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -257,7 +257,7 @@ nomem:
 	return -1;
 }
 
-void ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
+int ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
 		    int (*callback)(struct ofi_dyn_arr *arr, void *item,
 				    void *context))
 {
@@ -271,9 +271,10 @@ void ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
 			ret = callback(arr, ofi_array_item(arr, arr->chunk[c], i),
 				       context);
 			if (ret)
-				return;
+				return ret;
 		}
 	}
+	return 0;
 }
 
 void ofi_array_destroy(struct ofi_dyn_arr *arr)


### PR DESCRIPTION
If allocating an unexpected message context or queueing an unexpected message fails, sm2 needs to appropriately free the entry with the owner of the SRX