### PR TITLE
prov/shm: Add HMEM fallback protocol to enable CMA with HMEM

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -430,6 +430,7 @@ int ofi_hmem_host_unregister(void *addr);
 bool ofi_hmem_is_ipc_enabled(enum fi_hmem_iface iface);
 size_t ofi_hmem_get_ipc_handle_size(enum fi_hmem_iface iface);
 bool ofi_hmem_any_ipc_enabled(void);
+bool ofi_hmem_any_ipc_disabled(void);
 int ofi_hmem_dev_register(enum fi_hmem_iface iface, const void *addr,
 			  size_t size, uint64_t *handle);
 int ofi_hmem_dev_unregister(enum fi_hmem_iface iface, uint64_t handle);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -137,7 +137,7 @@ struct smr_tx_entry {
 	int64_t		peer_id;
 	void		*context;
 	struct iovec	iov[SMR_IOV_LIMIT];
-	uint32_t	iov_count;
+	size_t		iov_count;
 	uint64_t	op_flags;
 	size_t		bytes_done;
 	void		*map_ptr;
@@ -292,6 +292,16 @@ void smr_format_pend(struct smr_ep *ep, struct smr_tx_entry *pend,
 void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 			uint64_t tag, uint64_t data, uint64_t op_flags,
 			uintptr_t rma_cmd);
+void smr_format_iov(struct smr_cmd *cmd, const struct iovec *iov,
+		    size_t count, size_t total_len);
+int smr_format_ze_ipc(struct smr_ep *ep, int64_t id, struct smr_cmd *cmd,
+		const struct iovec *iov, size_t iov_count, uint64_t device,
+		size_t total_len, struct smr_region *smr);
+void smr_format_iov(struct smr_cmd *cmd, const struct iovec *iov,
+		    size_t count, size_t total_len);
+int smr_format_ipc(struct smr_cmd *cmd, const struct iovec *iov,
+		size_t iov_count, size_t len, struct smr_region *smr,
+		enum fi_hmem_iface iface, uint64_t device);
 size_t smr_copy_to_sar(struct smr_region *smr, struct smr_cmd *cmd,
 		         struct ofi_mr **mr, const struct iovec *iov,
 		         size_t count, size_t *bytes_done);

--- a/prov/shm/src/smr_util.h
+++ b/prov/shm/src/smr_util.h
@@ -43,6 +43,7 @@ extern "C" {
 #define SMR_FLAG_DEBUG	(1 << 1)
 #define SMR_FLAG_IPC_SOCK (1 << 2)
 #define SMR_FLAG_HMEM_ENABLED (1 << 3)
+#define SMR_FLAG_ACK (1 << 4)
 
 #define SMR_CMD_SIZE		256	/* align with 64-byte cache line */
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -282,6 +282,18 @@ bool ofi_hmem_any_ipc_enabled(void)
 	return false;
 }
 
+bool ofi_hmem_any_ipc_disabled(void)
+{
+	int iface;
+
+	//Skip hmem system which will never have ipc enabled
+	for (iface = FI_HMEM_SYSTEM + 1; iface < ARRAY_SIZE(hmem_ops); iface++)
+		if (ofi_hmem_is_initialized(iface) &&
+		    !ofi_hmem_is_ipc_enabled(iface))
+			return true;
+	return false;
+}
+
 int ofi_create_async_copy_event(enum fi_hmem_iface iface, uint64_t device,
 				ofi_hmem_async_event_t *event)
 {


### PR DESCRIPTION
CMA: "Cross Memory Attach"
HMEM: "Heterogeneous Memory"

CMA was not available before these changes because a sender could not guarentee that the receiving buffer is the same type of memory as the sending one.

This protocol now allows the sender to send a
Host (System) Memory buffer with HMEM enabled.
This is because in the case where the reciever realizes the destination is a Device Memory buffer, the reciever will create the necessary resources for doing a
H->D (Host to Device) copy and return the command to the sender's return queue. The sender will then do the H->D copy and resubmit the command as an
ACK (Acknowledgement) operation. When the reciever gets this ACK command it will cleanup the all reciever resources. This includes the ones that it opened in order for the sender to do the copy. It will pass the command back one more time to the sender's return queue to complete the transmission and cleanup the sender's resources.

This protocol also now allows for multiple iovs to be sent with HMEM enabled. Example case: iov[0] is system memory, iov[1] is ze memory, and iov[2] is cuda memory.
In this case the command will be re-used and sent back and forth until all the copies are completed. They will take the necessary fallback paths and set the "command ack" as needed. The protocol will only complete the transmission when the bytes_done equals the expected amount of data from the original command.

With this fallback protocol H->H copies can take the CMA fastpath when using shm on a node with HMEM devices.